### PR TITLE
Porting to Qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 *.DS_Store
 /build-qtscrob-Qt_5_5_0_clang_64-Debug/
 /build-qtscrob-Desktop-Debug/
+*.qmake.stash

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+* version 0.13.0 (2026-05-27)
+- Port to Qt 6 (Qt 5 no longer supported)
+- Replace all removed Qt5 APIs: toTime_t→toSecsSinceEpoch, qSort→std::sort,
+  QTextCodec→QString::fromLocal8Bit, QLayout::setMargin→setContentsMargins,
+  QTime timing→QElapsedTimer, QFileDialog::DirectoryOnly→Directory,
+  QCoreApplication::flush→processEvents, endl→Qt::endl
+- Fix QStringList forward-declaration (now a type alias in Qt6)
+- Re-enable libmtp source compilation (was accidentally commented out)
+- Fix LIBMTP_track_t pointer/copy bug in parse-mtp-libmtp.cpp
+- Drop CONFIG+=x11 (QtX11Extras dissolved in Qt6)
+- Introduce proper three-component version numbering (major.minor.patch)
+- Add localPipeline.sh: full local build + smoke-test script
+- Focus: Linux primary platform; macOS/Windows not actively maintained
+
 * version 0.12 (2015-10-02)
 - upgraded the whole project to be able to compile with the current Qt (5.5): adapted several includes and some function-calls
 - fixed some minor issues and typos
@@ -28,13 +42,13 @@
 
 * version 0.8 (2008-04-15)
 -Fix iTunesDB parsing
--Run submit in seperate thread 
+-Run submit in seperate thread
 
 * version 0.7 (2008-01-11)
 -Fix iTunesDB parsing
 -Fix GMT calculation on non-linux platforms
 -Add libcurl timeouts
--Automatically detect timezone and summertime details 
+-Automatically detect timezone and summertime details
 
 * version 0.6 (2007-09-30)
 -Separate all parsing and networking code to a backend library, libscrobble

--- a/README.md
+++ b/README.md
@@ -1,21 +1,89 @@
 # Qt Scrobbler
 
-Initially this was just a clone (fork) from the sourceforge-project of Robert Keevil and others. I adapted the code to make it buildable with Qt5 (before Qt4).  
-QTScrobbler ships both multiplatform GUI and CLI versions and requires Qt >= 5.5.
-Optional MTP support requires _libmtp-dev_ and _pkg-config_ (or the Windows 7 SDK if using MS Visual C++).
+Initially a clone/fork from the SourceForge project by Robert Keevil and others.
+The code has since been adapted for Qt5 and is now being ported to **Qt6**.
+QTScrobbler ships both a multiplatform GUI and a CLI version.
 
-`sudo apt-get install libmtp-dev pkg-config `
+Primary supported platform: **Linux**.
+macOS and Windows support is not actively maintained.
 
-## How to build?
+Optional MTP support requires `libmtp-dev` and `pkg-config`:
+
+```sh
+sudo apt-get install libmtp-dev pkg-config   # Debian/Ubuntu
+sudo pacman -S libmtp pkgconf                # Arch/Manjaro
 ```
-cd src && qmake && make  
-cd qt && qmake && make
+
+---
+
+## Requirements
+
+- Qt >= 6.x (tested with Qt 6.11.1)
+- A C++17 capable compiler (GCC 10+ or Clang 12+)
+- `qmake` pointing to Qt6 (verify with `qmake --version`)
+
+On Arch/Manjaro `qmake` already resolves to Qt6.
+On Debian/Ubuntu install `qt6-base-dev` and use `qmake6`.
+
+---
+
+## How to build
+
+### Full build (library + GUI + CLI)
+
+```sh
+cd src
+qmake
+make -j$(nproc)
 ```
 
-## Note
-With the most recent changes the MTP support (at least for Win) is dropped. It builds, but you have to pick the `scrobbler.log` manually on the device.  
-This is acceptable for me. I am also thinking about dropping the support for macOS and Win at all.  
-Additionally future porting to Qt6 (OpenSource) is planned.
+Binaries are written to `src/qt/` (GUI: `qtscrob`) and `src/cli/` (CLI: `scrobbler`).
+
+### GUI only
+
+```sh
+cd src/qt
+qmake
+make -j$(nproc)
+```
+
+### CLI only
+
+```sh
+cd src/cli
+qmake
+make -j$(nproc)
+```
+
+---
+
+## How to run
+
+### GUI
+
+```sh
+./src/qt/qtscrob
+# Optional flags:
+#   -c PATH   path to configuration file
+#   -v LEVEL  verbosity (0=error … 3=trace)
+```
+
+### CLI
+
+```sh
+./src/cli/scrobbler --help
+./src/cli/scrobbler -f /path/to/.scrobbler.log
+```
+
+---
+
+## Qt6 port status
+
+See [`port_to_qt6.md`](port_to_qt6.md) for the full compatibility assessment and list of required changes.
+
+---
 
 # last.fm
-Update: last.fm has stopped the support of groups and closed all existing ones. So there is no other way than github to exchange ideas.
+
+Last.fm stopped support for groups and closed all existing ones.
+GitHub issues are the place to exchange ideas and report bugs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qt Scrobbler
 
-Initially a clone/fork from the SourceForge project by Robert Keevil and others.
+Initially a clone/fork from the SourceForge project by Tomasz Mon, Robert Keevil and others.
 The code has since been adapted for Qt5 and is now being ported to **Qt6**.
 QTScrobbler ships both a multiplatform GUI and a CLI version.
 
@@ -28,6 +28,26 @@ On Debian/Ubuntu install `qt6-base-dev` and use `qmake6`.
 ---
 
 ## How to build
+
+### most simple: run localPipeline.sh ..
+
+```sh
+..
+============ Local Pipeline Summary ============
+ QtScrobbler v0.13.2
+Qt6 Check              : PASS Qt 6.11.1 at /usr/bin/qmake6
+Build Tools            : PASS make, g++, pkg-config present; 20 compile jobs
+Build: library         : PASS libscrobble.a (672K)
+Translations (.qm)     : PASS .qm files generated
+Build: GUI             : PASS qtscrob (576K)
+Build: CLI             : PASS scrobbler (340K)
+Smoke: CLI             : PASS --help exited 0 — usage text printed
+Smoke: GUI binary      : PASS /home/mpetrick/repos/QtScrobbler/src/qt/qtscrob — 576K
+Translations           : PASS de: 79/0 untranslated;  pl: 79/0 untranslated — total: 158 strings, 0 untranslated
+Unit Tests             : SKIP No QTest suite — add src/tests/ to enable
+Launch App             : PASS qtscrob started (detached)
+================================================
+```
 
 ### Full build (library + GUI + CLI)
 

--- a/localPipeline.sh
+++ b/localPipeline.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="${ROOT_DIR}/src"
+APP_VERSION="$(grep -oP '#define CLIENT_VERSION "\K[^"]+' "${SRC_DIR}/lib/common.h" 2>/dev/null || echo "unknown")"
 PIPELINE_LOG_DIR="${TMPDIR:-/tmp}/qtscrob-pipeline-$$"
 trap 'rm -rf "${PIPELINE_LOG_DIR}"' EXIT
 
@@ -58,6 +59,7 @@ run_with_log() {
 
 print_summary() {
     printf '\n============ Local Pipeline Summary ============\n'
+    printf ' QtScrobbler v%s\n' "${APP_VERSION}"
     local line
     for line in "${SUMMARY_LINES[@]}"; do printf '%s\n' "${line}"; done
     printf '================================================\n'
@@ -501,7 +503,7 @@ main() {
     parse_arguments "$@"
 
     log "================================================"
-    log " QtScrobbler — local pipeline"
+    log " QtScrobbler v${APP_VERSION} — local pipeline"
     log " Root    : ${ROOT_DIR}"
     log " Jobs    : ${JOBS} parallel compile threads"
     log " Date    : $(date '+%Y-%m-%d %H:%M:%S')"

--- a/localPipeline.sh
+++ b/localPipeline.sh
@@ -1,0 +1,644 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="${ROOT_DIR}/src"
+PIPELINE_LOG_DIR="${TMPDIR:-/tmp}/qtscrob-pipeline-$$"
+trap 'rm -rf "${PIPELINE_LOG_DIR}"' EXIT
+
+declare -a SUMMARY_LINES=()
+
+# State flags
+QT6_OK=0
+TOOLS_OK=0
+LIB_BUILD_OK=0
+GUI_BUILD_OK=0
+CLI_BUILD_OK=0
+CLI_SMOKE_OK=0
+GUI_SMOKE_OK=0
+LAUNCH_OK=0
+RUN_APP=true
+
+# Detail strings
+QT6_DETAILS=""
+TOOLS_DETAILS=""
+LIB_DETAILS=""
+GUI_DETAILS=""
+CLI_DETAILS=""
+CLI_SMOKE_DETAILS=""
+GUI_SMOKE_DETAILS=""
+TRANSLATION_DETAILS=""
+
+# Number of parallel compile jobs
+JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+# Will be set to the detected Qt6 qmake binary (qmake6 or qmake)
+QMAKE=""
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+log()   { printf '[INFO]  %s\n' "$*"; }
+warn()  { printf '[WARN]  %s\n' "$*" >&2; }
+error() { printf '[ERROR] %s\n' "$*" >&2; }
+
+mark_result() {
+    local label="$1" status="$2" details="$3"
+    SUMMARY_LINES+=("$(printf '%-22s : %-4s %s' "${label}" "${status}" "${details}")")
+}
+
+run_with_log() {
+    local log_path="$1"; shift
+    mkdir -p "${PIPELINE_LOG_DIR}"
+    "$@" 2>&1 | tee "${log_path}"
+    return "${PIPESTATUS[0]}"
+}
+
+print_summary() {
+    printf '\n============ Local Pipeline Summary ============\n'
+    local line
+    for line in "${SUMMARY_LINES[@]}"; do printf '%s\n' "${line}"; done
+    printf '================================================\n'
+}
+
+print_usage() {
+    cat <<EOF
+Usage: ./localPipeline.sh [--noRun] [--help]
+
+Local build and quality pipeline for QtScrobbler (Qt 6, Linux).
+
+Stages:
+  1.  Qt 6 check          — verify Qt >= 6.x via qmake
+  2.  Build tools         — make, g++, pkg-config (libmtp optional)
+  3.  Build: library      — compile static libscrobble (make -j${JOBS})
+  4.  Build: GUI + CLI    — parallel compile with make -j${JOBS} each
+  5.  Smoke: CLI          — scrobbler --help
+  6.  Smoke: GUI binary   — qtscrob present and executable
+  7.  Translations        — count unfinished strings in .ts catalogs
+  8.  Unit tests          — run QTest suite (SKIP until suite is added)
+  9.  Launch app          — start qtscrob once (suppress with --noRun)
+  10. Summary             — stage-by-stage result table
+
+Options:
+  --noRun   Skip launching the GUI app at the end
+  --help    Show this message
+
+Exit code 0 when all mandatory stages pass.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Stage 1: Qt6 availability
+# ---------------------------------------------------------------------------
+
+check_qt6() {
+    log "Stage 1 — Checking Qt6 availability..."
+
+    # Prefer the explicit Qt6 binary; fall back to plain qmake only when it is Qt6.
+    local candidates=("qmake6" "qmake6-qt6" "qmake")
+    local qmake_bin="" qt_version="" major=""
+
+    for candidate in "${candidates[@]}"; do
+        local bin
+        bin="$(command -v "${candidate}" 2>/dev/null)" || continue
+        qt_version="$("${bin}" --version 2>&1 | grep -oP 'Qt version \K[0-9]+\.[0-9]+\.[0-9]+')"
+        major="${qt_version%%.*}"
+        if [[ "${major}" == "6" ]]; then
+            qmake_bin="${bin}"
+            break
+        fi
+        log "  ${bin}: Qt ${qt_version} — not Qt 6, skipping"
+    done
+
+    if [[ -z "${qmake_bin}" ]]; then
+        QT6_DETAILS="No Qt 6 qmake found (tried: ${candidates[*]})"
+        error "  ${QT6_DETAILS}"
+        return 1
+    fi
+
+    QMAKE="${qmake_bin}"
+    QT6_DETAILS="Qt ${qt_version} at ${qmake_bin}"
+    log "  Qt version : ${qt_version}"
+    log "  qmake path : ${qmake_bin}"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build tools
+# ---------------------------------------------------------------------------
+
+check_build_tools() {
+    log "Stage 2 — Checking required build tools..."
+    log "  Parallel compile jobs: ${JOBS} (from nproc)"
+
+    local missing=()
+
+    for tool in make g++ pkg-config; do
+        if command -v "${tool}" >/dev/null 2>&1; then
+            local ver
+            ver="$("${tool}" --version 2>&1 | head -1)"
+            log "  ${tool}: ${ver}"
+        else
+            missing+=("${tool}")
+            error "  ${tool}: NOT FOUND"
+        fi
+    done
+
+    if pkg-config --exists libmtp 2>/dev/null; then
+        local mtp_ver
+        mtp_ver="$(pkg-config --modversion libmtp 2>/dev/null)"
+        log "  libmtp: ${mtp_ver} — MTP device support will be compiled"
+    else
+        warn "  libmtp: not found — MTP device support will be excluded"
+    fi
+
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+        TOOLS_DETAILS="missing: ${missing[*]}"
+        return 1
+    fi
+
+    TOOLS_DETAILS="make, g++, pkg-config present; ${JOBS} compile jobs"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Build helpers
+# ---------------------------------------------------------------------------
+
+distclean_subdir() {
+    local dir="$1"
+    if [[ -f "${dir}/Makefile" ]]; then
+        log "  Cleaning stale artifacts in ${dir}..."
+        make -C "${dir}" distclean -s 2>/dev/null || true
+    fi
+}
+
+# Write PASS or FAIL + details to a result file so parallel jobs can report back.
+build_subdir_to_file() {
+    local label="$1" dir="$2" result_file="$3"
+    local log_path="${PIPELINE_LOG_DIR}/${label}.log"
+
+    mkdir -p "${PIPELINE_LOG_DIR}"
+    distclean_subdir "${dir}"
+    log "  [${label}] ${QMAKE}..."
+    if ! bash -c "cd '${dir}' && '${QMAKE}'" >> "${log_path}" 2>&1; then
+        printf 'FAIL:qmake failed\n' > "${result_file}"
+        return 1
+    fi
+
+    log "  [${label}] make -j${JOBS}..."
+    if ! bash -c "cd '${dir}' && make -j${JOBS}" >> "${log_path}" 2>&1; then
+        local errors
+        errors="$(grep -cE 'error:' "${log_path}" 2>/dev/null || true)"
+        printf 'FAIL:compilation failed (%s error line(s))\n' "${errors}" > "${result_file}"
+        return 1
+    fi
+
+    printf 'PASS\n' > "${result_file}"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stage 3: Build library (must finish before GUI and CLI)
+# ---------------------------------------------------------------------------
+
+build_library() {
+    log "Stage 3 — Building static library (libscrobble) with -j${JOBS}..."
+    local result_file="${PIPELINE_LOG_DIR}/lib_result"
+
+    build_subdir_to_file "lib" "${SRC_DIR}/lib" "${result_file}"
+    local rc=$?
+
+    local artifact="${SRC_DIR}/lib/libscrobble.a"
+    if [[ "${rc}" -eq 0 && -f "${artifact}" ]]; then
+        local size
+        size="$(du -h "${artifact}" | awk '{print $1}')"
+        LIB_DETAILS="libscrobble.a (${size})"
+        log "  Artifact: ${artifact} (${size})"
+        return 0
+    fi
+
+    local fail_detail
+    fail_detail="$(cat "${result_file}" 2>/dev/null | cut -d: -f2-)"
+    LIB_DETAILS="${fail_detail:-compilation failed}"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Stage 4a: Compile .ts → .qm translation files
+# ---------------------------------------------------------------------------
+
+compile_translations() {
+    log "Stage 4a — Compiling translation catalogs (.ts → .qm)..."
+    local lang_dir="${SRC_DIR}/language"
+    local lrelease_bin
+    lrelease_bin="$(command -v lrelease 2>/dev/null || command -v lrelease-qt6 2>/dev/null || true)"
+
+    if [[ -z "${lrelease_bin}" ]]; then
+        warn "  lrelease not found — .qm files will not be generated; GUI/CLI builds may fail"
+        return 1
+    fi
+
+    local log_path="${PIPELINE_LOG_DIR}/lrelease.log"
+    mkdir -p "${PIPELINE_LOG_DIR}"
+    log "  Running ${lrelease_bin} on language.pro..."
+    if run_with_log "${log_path}" "${lrelease_bin}" -silent "${lang_dir}/language.pro"; then
+        local qm_count
+        qm_count="$(find "${lang_dir}" -name "*.qm" 2>/dev/null | wc -l)"
+        log "  Generated ${qm_count} .qm file(s)"
+        return 0
+    fi
+    warn "  lrelease failed — see ${log_path}"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Stage 4b: Build GUI and CLI in parallel
+# ---------------------------------------------------------------------------
+
+build_gui_and_cli_parallel() {
+    log "Stage 4 — Building GUI (qtscrob) and CLI (scrobbler) in parallel (-j${JOBS} each)..."
+
+    local gui_result="${PIPELINE_LOG_DIR}/gui_result"
+    local cli_result="${PIPELINE_LOG_DIR}/cli_result"
+
+    # Fire both builds in the background
+    build_subdir_to_file "gui" "${SRC_DIR}/qt"  "${gui_result}" &
+    local gui_pid=$!
+
+    build_subdir_to_file "cli" "${SRC_DIR}/cli" "${cli_result}" &
+    local cli_pid=$!
+
+    log "  Waiting for GUI (PID ${gui_pid}) and CLI (PID ${cli_pid})..."
+
+    local gui_rc=0 cli_rc=0
+    wait "${gui_pid}" || gui_rc=$?
+    wait "${cli_pid}" || cli_rc=$?
+
+    # --- GUI result ---
+    local gui_artifact="${SRC_DIR}/qt/qtscrob"
+    if [[ "${gui_rc}" -eq 0 && -x "${gui_artifact}" ]]; then
+        local size
+        size="$(du -h "${gui_artifact}" | awk '{print $1}')"
+        GUI_BUILD_OK=1
+        GUI_DETAILS="qtscrob (${size})"
+        log "  GUI PASS: ${gui_artifact} (${size})"
+    else
+        local fail_detail
+        fail_detail="$(cat "${gui_result}" 2>/dev/null | cut -d: -f2-)"
+        GUI_DETAILS="${fail_detail:-compilation failed}"
+        error "  GUI FAIL: ${GUI_DETAILS} — see ${PIPELINE_LOG_DIR}/gui.log"
+    fi
+
+    # --- CLI result ---
+    local cli_artifact="${SRC_DIR}/cli/scrobbler"
+    if [[ "${cli_rc}" -eq 0 && -x "${cli_artifact}" ]]; then
+        local size
+        size="$(du -h "${cli_artifact}" | awk '{print $1}')"
+        CLI_BUILD_OK=1
+        CLI_DETAILS="scrobbler (${size})"
+        log "  CLI PASS: ${cli_artifact} (${size})"
+    else
+        local fail_detail
+        fail_detail="$(cat "${cli_result}" 2>/dev/null | cut -d: -f2-)"
+        CLI_DETAILS="${fail_detail:-compilation failed}"
+        error "  CLI FAIL: ${CLI_DETAILS} — see ${PIPELINE_LOG_DIR}/cli.log"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Stage 5: CLI smoke test
+# ---------------------------------------------------------------------------
+
+smoke_test_cli() {
+    local binary="${SRC_DIR}/cli/scrobbler"
+    log "Stage 5 — CLI smoke test: ${binary} --help..."
+
+    if [[ ! -x "${binary}" ]]; then
+        CLI_SMOKE_DETAILS="binary not found at ${binary}"
+        error "  ${CLI_SMOKE_DETAILS}"
+        return 1
+    fi
+
+    local log_path="${PIPELINE_LOG_DIR}/cli_smoke.log"
+    # The CLI spins a Qt event loop; protect with a 5-second timeout.
+    if timeout 5 "${binary}" --help > "${log_path}" 2>&1; then
+        CLI_SMOKE_DETAILS="--help exited 0 — usage text printed"
+        log "  ${CLI_SMOKE_DETAILS}"
+        return 0
+    fi
+    local rc=$?
+
+    if grep -qiE "usage|option|help|scrobbler" "${log_path}" 2>/dev/null; then
+        CLI_SMOKE_DETAILS="usage text found (exit ${rc} treated as acceptable)"
+        log "  ${CLI_SMOKE_DETAILS}"
+        return 0
+    fi
+
+    if [[ "${rc}" -eq 124 ]]; then
+        CLI_SMOKE_DETAILS="timed out after 5 s (event-loop binary needs a log file argument)"
+        warn "  ${CLI_SMOKE_DETAILS}"
+    else
+        CLI_SMOKE_DETAILS="exited ${rc} with no recognisable usage output"
+        warn "  ${CLI_SMOKE_DETAILS}"
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Stage 6: GUI binary smoke test
+# ---------------------------------------------------------------------------
+
+smoke_test_gui_binary() {
+    local binary="${SRC_DIR}/qt/qtscrob"
+    log "Stage 6 — GUI binary smoke test: ${binary}..."
+
+    if [[ -x "${binary}" ]]; then
+        local size
+        size="$(du -h "${binary}" | awk '{print $1}')"
+        GUI_SMOKE_DETAILS="${binary} — ${size}"
+        log "  ${GUI_SMOKE_DETAILS}"
+        log "  (Headless display launch skipped — use --noRun to suppress full launch too)"
+        return 0
+    fi
+
+    GUI_SMOKE_DETAILS="binary not found at ${binary}"
+    error "  ${GUI_SMOKE_DETAILS}"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Stage 7: Translation audit
+# ---------------------------------------------------------------------------
+
+check_translations() {
+    log "Stage 7 — Auditing Qt translation catalogs in src/language/..."
+
+    local total_sources=0 total_unfinished=0
+    local detail_parts=()
+
+    shopt -s nullglob
+    for catalog in "${SRC_DIR}/language/"*.ts; do
+        local language source_count unfinished_count
+        language="$(basename "${catalog}" .ts)"
+        source_count="$(grep -c "<source>" "${catalog}" 2>/dev/null || true)"
+        unfinished_count="$(grep -c 'type="unfinished"' "${catalog}" 2>/dev/null || true)"
+        total_sources=$((total_sources + source_count))
+        total_unfinished=$((total_unfinished + unfinished_count))
+        detail_parts+=("${language}: ${source_count}/${unfinished_count} untranslated")
+        log "  ${language}: ${source_count} strings, ${unfinished_count} untranslated"
+    done
+    shopt -u nullglob
+
+    if [[ "${#detail_parts[@]}" -eq 0 ]]; then
+        TRANSLATION_DETAILS="no .ts catalogs found"
+        warn "  ${TRANSLATION_DETAILS}"
+        return 0
+    fi
+
+    local joined
+    joined="$(printf '%s;  ' "${detail_parts[@]}")"
+    TRANSLATION_DETAILS="${joined%%;  } — total: ${total_sources} strings, ${total_unfinished} untranslated"
+
+    [[ "${total_unfinished}" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Stage 8: Unit tests
+# ---------------------------------------------------------------------------
+
+run_unit_tests() {
+    log "Stage 8 — Searching for QTest unit test suite..."
+
+    local test_pros
+    test_pros="$(find "${SRC_DIR}" -name "*.pro" 2>/dev/null \
+        | xargs grep -l "QT += testlib" 2>/dev/null || true)"
+
+    if [[ -z "${test_pros}" ]]; then
+        log "  No QTest suite found (no .pro with 'QT += testlib')."
+        log "  → Create src/tests/ with QTest sub-projects to enable unit testing."
+        return 1
+    fi
+
+    log "  Found QTest project(s):"
+    local all_ok=0
+    while IFS= read -r pro; do
+        local pro_dir test_log
+        pro_dir="$(dirname "${pro}")"
+        test_log="${PIPELINE_LOG_DIR}/test_$(basename "${pro_dir}").log"
+        log "  Running tests in ${pro_dir}..."
+        if run_with_log "${test_log}" bash -c "cd '${pro_dir}' && '${QMAKE}' && make -j${JOBS} && make check"; then
+            log "  PASS: ${pro_dir}"
+        else
+            error "  FAIL: ${pro_dir}"
+            all_ok=1
+        fi
+    done <<< "${test_pros}"
+
+    return "${all_ok}"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 9: Launch the GUI application
+# ---------------------------------------------------------------------------
+
+launch_application() {
+    local binary="${SRC_DIR}/qt/qtscrob"
+    log "Stage 9 — Launching ${binary}..."
+
+    if [[ ! -x "${binary}" ]]; then
+        warn "  Binary not found — cannot launch."
+        return 1
+    fi
+
+    if [[ -z "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]]; then
+        warn "  No DISPLAY or WAYLAND_DISPLAY set — skipping launch in headless environment."
+        return 1
+    fi
+
+    log "  Starting qtscrob (display: ${DISPLAY:-${WAYLAND_DISPLAY:-}}). The pipeline will not wait for it."
+    "${binary}" &
+    local app_pid=$!
+    sleep 1
+    if kill -0 "${app_pid}" 2>/dev/null; then
+        disown "${app_pid}" 2>/dev/null || true
+        log "  qtscrob is running (PID ${app_pid})."
+        return 0
+    fi
+
+    wait "${app_pid}"
+    local rc=$?
+    if [[ "${rc}" -eq 0 ]]; then
+        return 0
+    fi
+    warn "  qtscrob exited immediately (exit ${rc})."
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_arguments() {
+    for arg in "$@"; do
+        case "${arg}" in
+            --noRun)  RUN_APP=false ;;
+            --help|-h) print_usage; exit 0 ;;
+            *) error "Unknown argument: ${arg}"; print_usage; exit 2 ;;
+        esac
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    local exit_code=0
+
+    parse_arguments "$@"
+
+    log "================================================"
+    log " QtScrobbler — local pipeline"
+    log " Root    : ${ROOT_DIR}"
+    log " Jobs    : ${JOBS} parallel compile threads"
+    log " Date    : $(date '+%Y-%m-%d %H:%M:%S')"
+    log " Run app : ${RUN_APP}"
+    log "================================================"
+
+    # Stage 1 — Qt6
+    if check_qt6; then
+        QT6_OK=1
+        mark_result "Qt6 Check" "PASS" "${QT6_DETAILS}"
+    else
+        mark_result "Qt6 Check" "FAIL" "${QT6_DETAILS}"
+        exit_code=1
+    fi
+
+    # Stage 2 — Build tools
+    if check_build_tools; then
+        TOOLS_OK=1
+        mark_result "Build Tools" "PASS" "${TOOLS_DETAILS}"
+    else
+        mark_result "Build Tools" "FAIL" "${TOOLS_DETAILS}"
+        exit_code=1
+    fi
+
+    # Stages 3-4 — Build (only when prerequisites pass)
+    if [[ "${QT6_OK}" -eq 1 && "${TOOLS_OK}" -eq 1 ]]; then
+
+        # Stage 3 — library (must be sequential; GUI+CLI depend on it)
+        if build_library; then
+            LIB_BUILD_OK=1
+            mark_result "Build: library" "PASS" "${LIB_DETAILS}"
+        else
+            mark_result "Build: library" "FAIL" "${LIB_DETAILS}"
+            exit_code=1
+        fi
+
+        # Stage 4a — compile translations (.qm needed by qrc in GUI and CLI)
+        if [[ "${LIB_BUILD_OK}" -eq 1 ]]; then
+            if compile_translations; then
+                mark_result "Translations (.qm)" "PASS" ".qm files generated"
+            else
+                mark_result "Translations (.qm)" "WARN" "lrelease failed — builds may miss .qm"
+            fi
+        fi
+
+        # Stage 4b — GUI + CLI in parallel (only when library is ready)
+        if [[ "${LIB_BUILD_OK}" -eq 1 ]]; then
+            build_gui_and_cli_parallel
+
+            if [[ "${GUI_BUILD_OK}" -eq 1 ]]; then
+                mark_result "Build: GUI" "PASS" "${GUI_DETAILS}"
+            else
+                mark_result "Build: GUI" "FAIL" "${GUI_DETAILS}"
+                exit_code=1
+            fi
+
+            if [[ "${CLI_BUILD_OK}" -eq 1 ]]; then
+                mark_result "Build: CLI" "PASS" "${CLI_DETAILS}"
+            else
+                mark_result "Build: CLI" "FAIL" "${CLI_DETAILS}"
+                exit_code=1
+            fi
+        else
+            mark_result "Build: GUI" "SKIP" "Library build failed"
+            mark_result "Build: CLI" "SKIP" "Library build failed"
+        fi
+
+    else
+        mark_result "Build: library" "SKIP" "Prerequisites unavailable"
+        mark_result "Build: GUI"     "SKIP" "Prerequisites unavailable"
+        mark_result "Build: CLI"     "SKIP" "Prerequisites unavailable"
+    fi
+
+    # Stage 5 — CLI smoke test
+    if [[ "${CLI_BUILD_OK}" -eq 1 ]]; then
+        if smoke_test_cli; then
+            CLI_SMOKE_OK=1
+            mark_result "Smoke: CLI" "PASS" "${CLI_SMOKE_DETAILS}"
+        else
+            mark_result "Smoke: CLI" "WARN" "${CLI_SMOKE_DETAILS}"
+        fi
+    else
+        mark_result "Smoke: CLI" "SKIP" "CLI build not available"
+    fi
+
+    # Stage 6 — GUI binary smoke test
+    if [[ "${GUI_BUILD_OK}" -eq 1 ]]; then
+        if smoke_test_gui_binary; then
+            GUI_SMOKE_OK=1
+            mark_result "Smoke: GUI binary" "PASS" "${GUI_SMOKE_DETAILS}"
+        else
+            mark_result "Smoke: GUI binary" "FAIL" "${GUI_SMOKE_DETAILS}"
+            exit_code=1
+        fi
+    else
+        mark_result "Smoke: GUI binary" "SKIP" "GUI build not available"
+    fi
+
+    # Stage 7 — Translations
+    if check_translations; then
+        mark_result "Translations" "PASS" "${TRANSLATION_DETAILS}"
+    else
+        mark_result "Translations" "WARN" "${TRANSLATION_DETAILS}"
+    fi
+
+    # Stage 8 — Unit tests
+    if run_unit_tests; then
+        mark_result "Unit Tests" "PASS" "QTest suite passed"
+    else
+        mark_result "Unit Tests" "SKIP" "No QTest suite — add src/tests/ to enable"
+    fi
+
+    # Stage 9 — Launch app
+    if [[ "${GUI_BUILD_OK}" -eq 1 ]]; then
+        if [[ "${RUN_APP}" == true ]]; then
+            if launch_application; then
+                LAUNCH_OK=1
+                mark_result "Launch App" "PASS" "qtscrob started (detached)"
+            else
+                mark_result "Launch App" "WARN" "Launch skipped or failed (non-fatal)"
+            fi
+        else
+            mark_result "Launch App" "SKIP" "Suppressed by --noRun"
+        fi
+    else
+        mark_result "Launch App" "SKIP" "GUI build not available"
+    fi
+
+    # Final verdict
+    if [[ "${exit_code}" -eq 0 ]]; then
+        log "Pipeline completed successfully."
+    else
+        error "Pipeline completed with one or more failing mandatory stages."
+    fi
+
+    print_summary
+    exit "${exit_code}"
+}
+
+main "$@"

--- a/port_to_qt6.md
+++ b/port_to_qt6.md
@@ -149,3 +149,14 @@ qmake
 make -j$(nproc)
 ./scrobbler --help
 ```
+
+
+----
+
+###  Follow-up modernisation (not yet done)
+
+- [ ] Migrate all ~30 old-style SIGNAL/SLOT connect() calls to typed pointer-to-member syntax for compile-time safety
+- [ ] Migrate build system from qmake to CMake (Qt6's officially recommended system)
+- [ ] Replace #include <QtCore> catch-all headers with specific module includes
+- [ ] Use QDateTime::currentSecsSinceEpoch() (shorter form) wherever only the integer timestamp is needed
+- [ ] Decide whether to officially drop Windows/macOS support and remove dead MTP/Win32 code paths

--- a/port_to_qt6.md
+++ b/port_to_qt6.md
@@ -1,0 +1,151 @@
+# Qt6 Porting Assessment
+
+## Current State
+
+The project was originally written for Qt4 and later adapted for Qt5.
+The local system ships **Qt 6.11.1** (Manjaro/Arch Linux) where `qmake` and `qmake6` both point to the Qt6 toolchain.
+Primary target going forward: **Linux only** (Windows and macOS support is deprioritised).
+
+---
+
+## Incompatible Qt5 APIs (compilation blockers)
+
+### 1. `QDateTime::toTime_t()` / `fromTime_t()` — removed in Qt6
+
+Replacement: `toSecsSinceEpoch()` / `fromSecsSinceEpoch()`.
+
+| File | Line(s) |
+|------|---------|
+| `src/lib/dbcache.cpp` | 152, 162 |
+| `src/lib/submit.cpp` | 248 |
+| `src/lib/libscrobble.cpp` | 41, 76 |
+| `src/qt/src/qtscrob.cpp` | 617 |
+| `src/lib/parse-mtp-win32.cpp` | 456, 462 (Windows-only, lower priority) |
+
+### 2. `qSort()` — removed in Qt6
+
+Replacement: `std::sort()` (from `<algorithm>`).
+
+| File | Line |
+|------|------|
+| `src/lib/libscrobble.cpp` | 159 |
+
+### 3. `QTextCodec` — moved out of QtCore into Qt5Compat
+
+`QTextCodec::codecForLocale()` is no longer available without pulling in the `core5compat` module.
+The single usage converts a C-string locale timezone name to `QString`.
+
+Replacement: `QString::fromLocal8Bit(tzname[tzindex])` — no extra module needed.
+
+| File | Lines |
+|------|-------|
+| `src/lib/libscrobble.cpp` | 85–86 |
+
+### 4. `QLayout::setMargin()` — removed in Qt6
+
+Replacement: `setContentsMargins(0, 0, 0, 0)`.
+
+| File | Line |
+|------|------|
+| `src/qt/src/console.cpp` | 65 |
+| `src/qt/src/help.cpp` | 35 |
+| `src/qt/src/qtscrob.cpp` | 136 |
+
+### 5. `CONFIG += x11` in qmake — QtX11Extras removed in Qt6
+
+The `x11extras` module was dissolved into the xcb platform plugin.
+The `CONFIG += x11` option is no longer valid and must be removed from `src/qt/qt.pro`.
+
+### 6. `endl` in `QTextStream` — deprecated global symbol
+
+Qt6 replaced the global `endl` stream manipulator with `Qt::endl`.
+Using the unqualified form produces deprecation warnings and can be ambiguous when `<ostream>` headers are pulled in transitively.
+
+| File | Affected lines |
+|------|----------------|
+| `src/qt/src/main.cpp` | 31, 33, 35, 37 |
+
+---
+
+## Deprecated (compiles but produces warnings)
+
+### Old-style SIGNAL/SLOT macros
+
+All `connect()` calls use the string-based macro syntax (`SIGNAL(...)` / `SLOT(...)`).
+This syntax still compiles in Qt6 but:
+- provides no compile-time type checking,
+- is flagged by `clazy` and Qt's own `-Wzero-as-null-pointer-constant` tooling,
+- is officially deprecated.
+
+Recommended migration: pointer-to-member function syntax.
+
+```cpp
+// old
+connect(btn, SIGNAL(clicked()), this, SLOT(open_log()));
+
+// new
+connect(btn, &QPushButton::clicked, this, &QTScrob::open_log);
+```
+
+Approximately 30 `connect()` calls spread across all source files need updating.
+
+---
+
+## Build system notes
+
+The project uses **qmake** (`.pro` files).
+Qt6 ships its own `qmake` (version 3.x) and it is the default on Arch/Manjaro, so existing `.pro` files continue to work after the API fixes above.
+CMake is the officially preferred build system for new Qt6 projects; migration is desirable long-term but out of scope for the initial port.
+
+---
+
+## What does NOT need changing
+
+- `QT += network sql xml` — all three modules exist in Qt6.
+- `QNetworkAccessManager` / `QNetworkReply` API — unchanged.
+- `QCryptographicHash` — unchanged.
+- `QSqlQuery` / `QSqlDatabase` — unchanged.
+- `QString`, `QUrl`, `QDateTime` (except `toTime_t`) — unchanged.
+- `QFile::exists()` static overload — still available (minor style note only).
+- `QString::fromStdWString()` — still available (Windows, secondary priority).
+- MTP support via `libmtp` + `pkg-config` detection in `common.pri` — still works.
+
+---
+
+## Recommended modernisation steps (beyond strict Qt6 compatibility)
+
+1. Migrate all `connect()` calls to the typed pointer-to-member syntax.
+2. Migrate the build system from qmake to CMake (Qt6's recommended system).
+3. Replace `#include <QtCore>` catch-all headers with specific includes.
+4. Consider using `QDateTime::currentSecsSinceEpoch()` (Qt 5.8+) where a plain integer is needed, instead of `QDateTime::currentDateTime().toSecsSinceEpoch()`.
+5. Drop dead Windows/MTP code paths if macOS and Windows support is officially abandoned.
+
+---
+
+## Build verification on Linux (Qt 6.11.1, Manjaro)
+
+After applying the fixes above, the standard build should work:
+
+```sh
+cd src
+qmake
+make -j$(nproc)
+```
+
+To build only the GUI application:
+
+```sh
+cd src/qt
+qmake
+make -j$(nproc)
+./qtscrob
+```
+
+To build only the CLI:
+
+```sh
+cd src/cli
+qmake
+make -j$(nproc)
+./scrobbler --help
+```

--- a/src/cli/app.cpp
+++ b/src/cli/app.cpp
@@ -120,7 +120,7 @@ bool app::parse_cmd(int argc, char** argv)
             case '?':
                 break;
             default:
-                out << "Unknown option \"" << QChar(c) << "\"" << endl;
+                out << "Unknown option \"" << QChar(c) << "\"" << Qt::endl;
                 return false;
         }
     }
@@ -130,7 +130,7 @@ bool app::parse_cmd(int argc, char** argv)
         out << tr("Unknown option argument:");
         while (optind < argc)
             out << " " << argv[optind++];
-        out << endl;
+        out << Qt::endl;
         return false;
     }
     return true;
@@ -145,34 +145,34 @@ void app::print_usage()
     else
         dst = "No";
 
-    out << "scrobbler (v" << CLIENT_VERSION << "): " << tr("a Last.fm uploader") << endl;
-    out << endl;
-    out << tr("Mandatory arguments to long options are mandatory for short options too.") << endl;
-    out << endl;
-    out << tr("Required:") << endl;
-    out << "  -c, --config             " << tr("Location to the config file") << endl;
-    out << "                           " << tr("The config file holds the site configurations") << endl;
-    out << "                           " << tr("(usernames, passwords), proxy info, timezone offsets etc") << endl;
-    out << endl;
-    out << tr("Methods:") << endl;
-    out << "  -d, --database           " << tr("Submit ipod database") << endl;
-    out << "  -f, --file               " << tr("Submit .scrobbler.log file") << endl;
+    out << "scrobbler (v" << CLIENT_VERSION << "): " << tr("a Last.fm uploader") << Qt::endl;
+    out << Qt::endl;
+    out << tr("Mandatory arguments to long options are mandatory for short options too.") << Qt::endl;
+    out << Qt::endl;
+    out << tr("Required:") << Qt::endl;
+    out << "  -c, --config             " << tr("Location to the config file") << Qt::endl;
+    out << "                           " << tr("The config file holds the site configurations") << Qt::endl;
+    out << "                           " << tr("(usernames, passwords), proxy info, timezone offsets etc") << Qt::endl;
+    out << Qt::endl;
+    out << tr("Methods:") << Qt::endl;
+    out << "  -d, --database           " << tr("Submit ipod database") << Qt::endl;
+    out << "  -f, --file               " << tr("Submit .scrobbler.log file") << Qt::endl;
 #ifdef HAVE_MTP
-    out << "  -m, --mtp                " << tr("Submit MTP device") << endl;
+    out << "  -m, --mtp                " << tr("Submit MTP device") << Qt::endl;
 #endif
-    out << endl;
-    out << "Options:" << endl;
-    out << "  -l, --location           " << tr("Mount point of the player") << endl;
-    out << "  -t, --timestamp=WHEN     " << tr("UNIX timestamp to recalculate from") << endl;
-    out << "  -n, --now                " << tr("Re-calculate the play time to now") << endl;
-    out << "  -r, --recalc=TIME        " << tr("Re-calculate the time when tracks were played") << endl;
-    out << "  -v, --verbose=LEVEL      " << tr("Verbosity level") << endl;
-    out << endl;
-    out << tr("Auto-detected timezone info:") << endl;
-    out << tr("Timezone: ") << scrob->get_zonename() << endl;
-    out << tr("Offset: ") << scrob->offset_str() << endl;
-    out << tr("Daylight saving: ") << dst << endl;
-    out << endl;
+    out << Qt::endl;
+    out << "Options:" << Qt::endl;
+    out << "  -l, --location           " << tr("Mount point of the player") << Qt::endl;
+    out << "  -t, --timestamp=WHEN     " << tr("UNIX timestamp to recalculate from") << Qt::endl;
+    out << "  -n, --now                " << tr("Re-calculate the play time to now") << Qt::endl;
+    out << "  -r, --recalc=TIME        " << tr("Re-calculate the time when tracks were played") << Qt::endl;
+    out << "  -v, --verbose=LEVEL      " << tr("Verbosity level") << Qt::endl;
+    out << Qt::endl;
+    out << tr("Auto-detected timezone info:") << Qt::endl;
+    out << tr("Timezone: ") << scrob->get_zonename() << Qt::endl;
+    out << tr("Offset: ") << scrob->offset_str() << Qt::endl;
+    out << tr("Daylight saving: ") << dst << Qt::endl;
+    out << Qt::endl;
 }
 
 void app::run()
@@ -185,7 +185,7 @@ void app::run()
 
     if (do_time && do_now)
     {
-        out << tr("You can only use one of -n and -r") << endl;
+        out << tr("You can only use one of -n and -r") << Qt::endl;
         delete scrob;
         this->quit();
         return;
@@ -222,7 +222,7 @@ void app::run()
 
     if (num_method != 1)
     {
-        out << tr("Error - no (single) method specified") << endl;
+        out << tr("Error - no (single) method specified") << Qt::endl;
         print_usage();
         delete scrob;
         this->quit();
@@ -237,7 +237,7 @@ void app::parsed(bool success)
     QTextStream out(stdout);
     if (!success)
     {
-        out << tr("Error parsing data: ") << scrob->get_error_str() << endl;
+        out << tr("Error parsing data: ") << scrob->get_error_str() << Qt::endl;
         this->quit();
         return;
     }
@@ -256,9 +256,9 @@ void app::scrobbled(bool success)
     QTextStream out(stdout);
     if (!success)
     {
-        out << tr("Submission failed: ") << scrob->get_error_str() << endl;
+        out << tr("Submission failed: ") << scrob->get_error_str() << Qt::endl;
     } else {
-        out << tr("Submission complete") << endl;
+        out << tr("Submission complete") << Qt::endl;
     }
     delete scrob;
     this->quit();

--- a/src/cli/app.h
+++ b/src/cli/app.h
@@ -51,7 +51,6 @@ private:
 
 public:
     app(int&, char**);
-    app();
     bool parse_cmd(int argc, char** argv);
     
 public slots:

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.12"
+#define CLIENT_VERSION "0.13.1"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.1"
+#define CLIENT_VERSION "0.13.3"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/dbcache.cpp
+++ b/src/lib/dbcache.cpp
@@ -149,7 +149,7 @@ int DBCache::get_track_length(QString artist, QString title)
     {
         int ret = query.value(0).toInt();
         uint age = query.value(1).toInt();
-        uint now = QDateTime::currentDateTime().toTime_t();
+        uint now = QDateTime::currentDateTime().toSecsSinceEpoch();
         if (age > (now - MAX_TRACK_LENGTH_AGE))
             return ret;
     }
@@ -159,7 +159,7 @@ int DBCache::get_track_length(QString artist, QString title)
 
 void DBCache::set_track_length(QString artist, QString title, int length)
 {
-    uint time = QDateTime::currentDateTime().toTime_t();
+    uint time = QDateTime::currentDateTime().toSecsSinceEpoch();
     // use prepare to ensure the strings are correctly escaped
     query.prepare("replace into track_length (artist,title,length,timestamp) "
                        "values (:artist,:title,:length,:timestamp)");

--- a/src/lib/gettrackinfo.h
+++ b/src/lib/gettrackinfo.h
@@ -23,7 +23,7 @@
 #include <QXmlStreamReader>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QThread>
 #include "common.h"
 
@@ -52,7 +52,7 @@ private:
     QUrl url;
     QNetworkAccessManager *manager;
     QNetworkRequest request;
-    QTime time;
+    QElapsedTimer time;
     int index;
     scrob_entry track_info;
 };

--- a/src/lib/lib.pri
+++ b/src/lib/lib.pri
@@ -17,12 +17,11 @@ HEADERS += libscrobble.h \
     gettrackinfo.h \
     dbcache.h
 
-##mtp joy
-#contains (MTP, WPD) {
-#    SOURCES += parse-mtp-win32.cpp
-#    HEADERS += parse-mtp.h
-#}
-#contains (MTP, LIBMTP) {
-#    SOURCES += parse-mtp-libmtp.cpp
-#    HEADERS += parse-mtp.h
-#}
+contains (MTP, WPD) {
+    SOURCES += parse-mtp-win32.cpp
+    HEADERS += parse-mtp.h
+}
+contains (MTP, LIBMTP) {
+    SOURCES += parse-mtp-libmtp.cpp
+    HEADERS += parse-mtp.h
+}

--- a/src/lib/libscrobble.cpp
+++ b/src/lib/libscrobble.cpp
@@ -16,6 +16,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
+#include <algorithm>
 #include <cmath> // abs
 #include "libscrobble.h"
 
@@ -38,7 +39,7 @@ void Scrobble::clear_method()
 
 uint Scrobble::get_gmt()
 {
-    return QDateTime::currentDateTime().toTime_t();
+    return QDateTime::currentDateTime().toSecsSinceEpoch();
 }
 
 Scrobble::Scrobble()
@@ -73,7 +74,7 @@ Scrobble::Scrobble()
     a = QDateTime::currentDateTime().toUTC();
     b = QDateTime::currentDateTime().toLocalTime();
 
-    gmt_offset = b.toTime_t() -a.toTime_t();
+    gmt_offset = b.toSecsSinceEpoch() - a.toSecsSinceEpoch();
 
     /* initialise TZ variables */
     tzset();
@@ -82,8 +83,7 @@ Scrobble::Scrobble()
     is_dst = daylight;
     int tzindex = (is_dst)?1:0;
 
-    QTextCodec *codec = QTextCodec::codecForLocale();
-    zonename = codec->toUnicode(tzname[tzindex]);
+    zonename = QString::fromLocal8Bit(tzname[tzindex]);
 
     if (is_dst < 0)
         add_log(LOG_ERROR, "is_dst < 0");
@@ -156,7 +156,7 @@ void Scrobble::update_track(scrob_entry track, int track_index)
 void Scrobble::sort_tracks()
 {
     // sort by played Date/Time
-    qSort(entries.begin(), entries.end(), entry_less_than);
+    std::sort(entries.begin(), entries.end(), entry_less_than);
 }
 
 // called before submission to ensure data sent is valid

--- a/src/lib/libscrobble.cpp
+++ b/src/lib/libscrobble.cpp
@@ -67,14 +67,7 @@ Scrobble::Scrobble()
     proxy_set = false;
     db_ready = cache->init();
 
-    // belt and braces
-    QDateTime a, b;
-    a.setTimeSpec(Qt::UTC);
-    b.setTimeSpec(Qt::LocalTime);
-    a = QDateTime::currentDateTime().toUTC();
-    b = QDateTime::currentDateTime().toLocalTime();
-
-    gmt_offset = b.toSecsSinceEpoch() - a.toSecsSinceEpoch();
+    gmt_offset = QDateTime::currentDateTime().offsetFromUtc();
 
     /* initialise TZ variables */
     tzset();
@@ -315,7 +308,7 @@ void Scrobble::add_log(LOG_LEVEL level, QString msg)
     log_messages.push_back(tmp);
 
     if (level <= log_print_level)
-        QTextStream(stdout) << LOG_LEVEL_NAMES[level] << ": " << msg << endl;
+        QTextStream(stdout) << LOG_LEVEL_NAMES[level] << ": " << msg << Qt::endl;
 
     if (LOG_ERROR == level)
         error_str = msg;

--- a/src/lib/parse-mtp-libmtp.cpp
+++ b/src/lib/parse-mtp-libmtp.cpp
@@ -118,7 +118,7 @@ void Parse_MTP::mtp_iterate(bool clear_tracks)
             while (track != NULL)
             {
                 mtp_trackinfo(iter, track, clear_tracks);
-                LIBMTP_track_t tmp = track;
+                LIBMTP_track_t *tmp = track;
                 track = track->next;
                 LIBMTP_destroy_track_t(tmp);
             }

--- a/src/lib/submit.cpp
+++ b/src/lib/submit.cpp
@@ -245,7 +245,7 @@ void Submit::senddata_finished(QNetworkReply *reply)
 void Submit::handshake()
 {
     //emit add_log(LOG_INFO, "Submit::handshake");
-    QString time_str = QString::number(QDateTime::currentDateTime().toTime_t());
+    QString time_str = QString::number(QDateTime::currentDateTime().toSecsSinceEpoch());
 
     QCryptographicHash auth_hash(QCryptographicHash::Md5);
     auth_hash.addData(QString(context.password_hash + time_str).toLocal8Bit());

--- a/src/qt/qt.pro
+++ b/src/qt/qt.pro
@@ -41,8 +41,7 @@ INCLUDEPATH += . \
     ../lib \
     ../common
 DEPENDPATH += ../lib
-CONFIG += qt \
-    x11
+CONFIG += qt
 
 win32 {
     CONFIG(debug, debug|release) {

--- a/src/qt/src/console.cpp
+++ b/src/qt/src/console.cpp
@@ -62,7 +62,7 @@ Console::Console(QTScrob *parent) : QDialog(parent) {
 	btmlayout->addWidget(btncopy);
 
 	QVBoxLayout *layout = new QVBoxLayout;
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(edtConsole);
 	layout->addLayout(btmlayout);
 

--- a/src/qt/src/help.cpp
+++ b/src/qt/src/help.cpp
@@ -32,7 +32,7 @@ Help::Help(QTScrob *parent) : QDialog( parent ) {
 		edtHelp->setHtml(file.readAll());
 
 	QVBoxLayout *layout = new QVBoxLayout;
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(edtHelp);
 
 	setLayout(layout);

--- a/src/qt/src/main.cpp
+++ b/src/qt/src/main.cpp
@@ -28,13 +28,13 @@
 void printusage()
 {
     QTextStream out(stdout);
-    out << "QTScrob (v" << CLIENT_VERSION << ")" << endl;
-    out << endl;
-    out << "Options:" << endl;
-    out << "  -c, --config=PATH    Path to the configuration file" << endl;
-    out << "  -h, --help           This message" << endl;
-    out << "  -v, --verbose=LEVEL  Verbosity level" << endl;
-    out << endl;
+    out << "QTScrob (v" << CLIENT_VERSION << ")" << Qt::endl;
+    out << Qt::endl;
+    out << "Options:" << Qt::endl;
+    out << "  -c, --config=PATH    Path to the configuration file" << Qt::endl;
+    out << "  -h, --help           This message" << Qt::endl;
+    out << "  -v, --verbose=LEVEL  Verbosity level" << Qt::endl;
+    out << Qt::endl;
 }
 
 int main(int argc, char **argv)
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
         out << "Unknown option argument:";
         while (optind < argc)
             out << " " << argv[optind++];
-        out << endl;
+        out << Qt::endl;
         exit(1);
     }
 

--- a/src/qt/src/qtscrob.cpp
+++ b/src/qt/src/qtscrob.cpp
@@ -133,7 +133,7 @@ void QTScrob::setupWidgets() {
 #endif
 
 	QGridLayout *layout = new QGridLayout(centralWidget);
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setColumnStretch(0, 1);
 	layout->addWidget(btnOpen, 0, 1);
 	layout->addWidget(btnOpeniTunes, 0, 2);
@@ -614,7 +614,7 @@ void QTScrob::changeRow(int r, int c) {
 			{
 				QDateTime dt = QDateTime::fromString(logTable->item(r, c)->text(), "yyyy-MM-dd hh:mm:ss");
 				dt.setTimeSpec(Qt::UTC);
-				tmp.when = dt.toTime_t();
+				tmp.when = dt.toSecsSinceEpoch();
 			}
 			break;
 	}

--- a/src/qt/src/qtscrob.cpp
+++ b/src/qt/src/qtscrob.cpp
@@ -332,7 +332,7 @@ void QTScrob::open(SCROBBLE_METHOD method) {
 	else
 	{
 		QFileDialog *dlg = new QFileDialog;
-		dlg->setFileMode(QFileDialog::DirectoryOnly);
+		dlg->setFileMode(QFileDialog::Directory);
 		if (!scrob->conf->mru.isEmpty())
 			dlg->setHistory(scrob->conf->mru);
 
@@ -637,7 +637,7 @@ void QTScrob::scrobble() {
 	}
 
 	// make sure the widget appears before we submit()
-	QCoreApplication::flush();
+	QCoreApplication::processEvents();
 
 	lblStatus->setText(tr("Submitting data to server..."));
 	btnSubmit->setEnabled(false);

--- a/src/qt/src/qtscrob.h
+++ b/src/qt/src/qtscrob.h
@@ -46,7 +46,7 @@ class QTableWidgetItem;
 class QMenu;
 class QAction;
 class QWidget;
-class QStringList;
+#include <QStringList>
 class QSettings;
 class QTranslator;
 class QLabel;


### PR DESCRIPTION
Solves #3

## Summary
  
  Closes #3. Full Qt6 port of QtScrobbler — all Qt5-only APIs replaced, both
  GUI and CLI build and run cleanly on Qt 6.11.1 (Arch/Manjaro Linux).
  No Qt5Compat dependency.

  ## What changed
  
  **API migrations (compilation blockers)**

  | Removed Qt5 API | Replacement | Files |
  |---|---|---|
  | `QDateTime::toTime_t()` | `toSecsSinceEpoch()` | `dbcache.cpp`, `submit.cpp`, `libscrobble.cpp`, `qtscrob.cpp` |
  | `QTime::start/restart/elapsed()` | `QElapsedTimer` | `gettrackinfo.h` |
  | `QDateTime::setTimeSpec()` | `offsetFromUtc()` | `libscrobble.cpp` |
  | `qSort()` | `std::sort()` + `<algorithm>` | `libscrobble.cpp` |
  | `QTextCodec::codecForLocale()` | `QString::fromLocal8Bit()` | `libscrobble.cpp` |
  | `QLayout::setMargin()` | `setContentsMargins(0,0,0,0)` | `console.cpp`, `help.cpp`, `qtscrob.cpp` |
  | `QFileDialog::DirectoryOnly` | `QFileDialog::Directory` | `qtscrob.cpp` |
  | `QCoreApplication::flush()` | `processEvents()` | `qtscrob.cpp` |
  | `endl` (global) | `Qt::endl` | `main.cpp`, `libscrobble.cpp`, `app.cpp` |
  | `class QStringList` forward-decl | `#include <QStringList>` | `qtscrob.h` |
  | `CONFIG += x11` | removed | `qt.pro` |

  **Linker / build fixes**
  
  - `app::app()` declared but never defined — Qt6 moc now references it; orphan declaration removed (`app.h`)
  - MTP sources commented out in `lib.pri` while `HAVE_LIBMTP` remained active, causing undefined-reference link errors — source block
  re-enabled
  - Pointer/copy bug in `parse-mtp-libmtp.cpp` fixed (`LIBMTP_track_t` vs `LIBMTP_track_t *`)

  **Infrastructure added**

  - `localPipeline.sh` — builds library, GUI, and CLI (GUI+CLI run in parallel
    with `-j$(nproc)`), CLI smoke test, translation audit, stage-by-stage
    pass/fail summary; auto-launches the app when a display is available
  - `port_to_qt6.md` — full porting assessment with all changed APIs and
    remaining modernisation recommendations
  - `pre-commit` git hook — auto-increments the patch digit of `CLIENT_VERSION`
    on every commit; version appears in the pipeline summary
  - Three-component versioning introduced (`0.13.x`); CHANGELOG updated

  ## Acceptance criteria

  - [x] Builds with Qt 6.11.1 — zero errors, no Qt5Compat
  - [x] `qtscrob` (GUI) builds and launches
  - [x] `scrobbler --help` (CLI) exits 0 and prints usage
  - [x] MTP device support compiles on Linux (libmtp via pkg-config)
  - [x] Both translation catalogs (de, pl) fully translated — 0 unfinished strings
  - [ ] SIGNAL/SLOT → typed `connect()` migration (~30 calls) — deferred, tracked in `port_to_qt6.md`
  - [ ] qmake → CMake migration — deferred, tracked in `port_to_qt6.md`

  ## Verification

  ```sh
  ./localPipeline.sh --noRun

   QtScrobbler v0.13.1 — local pipeline
  Qt6 Check              : PASS  Qt 6.11.1 at /usr/bin/qmake6
  Build Tools            : PASS  make, g++, pkg-config present; 20 compile jobs
  Build: library         : PASS  libscrobble.a (672K)
  Translations (.qm)     : PASS  .qm files generated
  Build: GUI             : PASS  qtscrob (576K)
  Build: CLI             : PASS  scrobbler (340K)
  Smoke: CLI             : PASS  --help exited 0 — usage text printed
  Smoke: GUI binary      : PASS  qtscrob present and executable
  Translations           : PASS  de: 79/0 untranslated; pl: 79/0 untranslated
  Unit Tests             : SKIP  No QTest suite — add src/tests/ to enable
