### PR TITLE
ci: add GitHub Actions for CI and release builds, closes #6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+    tags-ignore: ['v*']
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & smoke test (Ubuntu 24.04 / Qt6)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Qt6 and build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            cmake build-essential pkg-config \
+            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools \
+            libgl-dev libmtp-dev
+
+      - name: Add Qt6 tools to PATH
+        run: echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
+
+      - name: Read version
+        id: meta
+        run: |
+          VER=$(grep -oP '#define CLIENT_VERSION "\K[^"]+' src/lib/common.h)
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: CMake configure
+        run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+
+      - name: CMake build
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Smoke test — CLI --help
+        run: timeout 5 ./build/scrobbler --help
+
+      - name: Smoke test — GUI binary exists and is executable
+        run: test -x ./build/qtscrob
+
+      - name: Generate build report
+        if: always()
+        run: |
+          VER="${{ steps.meta.outputs.version }}"
+          DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          GUI_SIZE=$(du -sh build/qtscrob    2>/dev/null | awk '{print $1}' || echo 'N/A')
+          CLI_SIZE=$(du -sh build/scrobbler  2>/dev/null | awk '{print $1}' || echo 'N/A')
+          LIB_SIZE=$(du -sh build/libscrobble.a 2>/dev/null | awk '{print $1}' || echo 'N/A')
+
+          cat > build-report.md << REPORT
+          # Build Report — QtScrobbler v${VER}
+
+          **Date:** ${DATE}
+          **Ref:** \`${{ github.ref }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Runner:** ubuntu-24.04
+
+          ## Results
+
+          | Stage | Status | Detail |
+          |---|---|---|
+          | CMake configure | ✅ | |
+          | CMake build | ✅ | lib: ${LIB_SIZE} · qtscrob: ${GUI_SIZE} · scrobbler: ${CLI_SIZE} |
+          | Smoke: CLI \`--help\` | ✅ | exit 0 |
+          | Smoke: GUI binary | ✅ | executable present |
+          REPORT
+
+      - name: Upload build report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-report
+          path: build-report.md
+          retention-days: 30
+
+      - name: Upload binaries
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-linux-x86_64
+          path: |
+            build/qtscrob
+            build/scrobbler
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Qt6 and build dependencies
+      - name: Install system dependencies (non-Qt)
         run: |
           sudo apt-get update -q
           sudo apt-get install -y \
             cmake build-essential pkg-config \
-            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools \
             libgl-dev libmtp-dev
 
-      - name: Add Qt6 tools to PATH
-        run: echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
+      - name: Install Qt 6.8
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '6.8.*'
+          host: linux
+          target: desktop
+          arch: linux_gcc_64
+          cache: true
 
       - name: Read version
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  push:
+    tags: ['v[0-9]*']
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build release binaries (Ubuntu 24.04 / Qt6)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Qt6 and build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            cmake build-essential pkg-config \
+            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools \
+            libgl-dev libmtp-dev
+
+      - name: Add Qt6 tools to PATH
+        run: echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
+
+      - name: Extract version and tag
+        id: meta
+        run: |
+          TAG="${GITHUB_REF_NAME}"           # e.g. v0.13.5
+          VER="${TAG#v}"                     # strip leading v → 0.13.5
+          ARCHIVE="qtscrobbler-${VER}-linux-x86_64"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VER"     >> "$GITHUB_OUTPUT"
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: CMake configure
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: CMake build
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Smoke test — CLI
+        run: timeout 5 ./build/scrobbler --help
+
+      - name: Strip binaries
+        run: |
+          strip --strip-unneeded build/qtscrob
+          strip --strip-unneeded build/scrobbler
+
+      - name: Package release archive
+        id: pkg
+        run: |
+          ARCHIVE="${{ steps.meta.outputs.archive }}"
+          mkdir -p "dist/${ARCHIVE}"
+          cp build/qtscrob build/scrobbler README.md "dist/${ARCHIVE}/"
+          cd dist
+          tar -czf "${ARCHIVE}.tar.gz" "${ARCHIVE}/"
+          SHA=$(sha256sum "${ARCHIVE}.tar.gz" | awk '{print $1}')
+          echo "archive_path=dist/${ARCHIVE}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA}"                        >> "$GITHUB_OUTPUT"
+          echo "Packaged: ${ARCHIVE}.tar.gz  sha256=${SHA}"
+
+      - name: Generate build report
+        id: report
+        run: |
+          VER="${{ steps.meta.outputs.version }}"
+          DATE="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          ARCHIVE="${{ steps.meta.outputs.archive }}"
+          SHA="${{ steps.pkg.outputs.sha256 }}"
+          GUI_STRIPPED=$(du -sh build/qtscrob   | awk '{print $1}')
+          CLI_STRIPPED=$(du -sh build/scrobbler  | awk '{print $1}')
+          LIB_SIZE=$(du -sh build/libscrobble.a  | awk '{print $1}')
+          TARBALL_SIZE=$(du -sh "dist/${ARCHIVE}.tar.gz" | awk '{print $1}')
+
+          cat > build-report.md << REPORT
+          # Build Report — QtScrobbler v${VER}
+
+          **Date:** ${DATE}
+          **Tag:** \`${{ steps.meta.outputs.tag }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Runner:** ubuntu-24.04 / Qt 6
+
+          ## Release artifacts
+
+          | File | Size | SHA-256 |
+          |---|---|---|
+          | qtscrob (GUI, stripped) | ${GUI_STRIPPED} | — |
+          | scrobbler (CLI, stripped) | ${CLI_STRIPPED} | — |
+          | ${ARCHIVE}.tar.gz | ${TARBALL_SIZE} | \`${SHA}\` |
+
+          ## Build stages
+
+          | Stage | Status | Detail |
+          |---|---|---|
+          | CMake configure | ✅ | |
+          | CMake build | ✅ | lib: ${LIB_SIZE} |
+          | Smoke: CLI \`--help\` | ✅ | exit 0 |
+          | Strip binaries | ✅ | |
+          | Package archive | ✅ | ${TARBALL_SIZE} |
+
+          ## Runtime requirements
+
+          These binaries are dynamically linked and require Qt 6 on the target system:
+
+          \`\`\`sh
+          # Arch / Manjaro
+          sudo pacman -S qt6-base libmtp
+
+          # Debian / Ubuntu 24.04
+          sudo apt-get install qt6-base-dev libmtp9
+          \`\`\`
+          REPORT
+
+      - name: Upload build report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-report-${{ steps.meta.outputs.version }}
+          path: build-report.md
+          retention-days: 90
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: QtScrobbler ${{ steps.meta.outputs.version }}
+          body_path: build-report.md
+          files: ${{ steps.pkg.outputs.archive_path }}
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Qt6 and build dependencies
+      - name: Install system dependencies (non-Qt)
         run: |
           sudo apt-get update -q
           sudo apt-get install -y \
             cmake build-essential pkg-config \
-            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools \
             libgl-dev libmtp-dev
 
-      - name: Add Qt6 tools to PATH
-        run: echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
+      - name: Install Qt 6.8
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '6.8.*'
+          host: linux
+          target: desktop
+          arch: linux_gcc_64
+          cache: true
 
       - name: Extract version and tag
         id: meta

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(QtScrobbler LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Treat every warning as an error — zero-warning policy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(QtScrobbler LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Treat every warning as an error — zero-warning policy
+add_compile_options(-Wall -Werror)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.28)
 project(QtScrobbler LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -17,7 +17,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Qt6
-find_package(Qt6 6.0 REQUIRED COMPONENTS Core Network Sql Xml Widgets)
+find_package(Qt6 6.8 REQUIRED COMPONENTS Core Network Sql Xml Widgets)
 
 # Optional MTP support via libmtp (pkg-config)
 find_package(PkgConfig QUIET)

--- a/GITHUB_ACTIONS.md
+++ b/GITHUB_ACTIONS.md
@@ -1,0 +1,96 @@
+# GitHub Actions — QtScrobbler
+
+Two workflows automate building and publishing QtScrobbler.
+
+---
+
+## CI (`ci.yml`)
+
+**Triggers:** every push to any branch (except version tags) and every pull request against `master`.
+
+What it does:
+1. Installs Qt 6, cmake, libmtp on an Ubuntu 24.04 runner
+2. Runs `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
+3. Builds with `cmake --build build --parallel`
+4. Smoke-tests `scrobbler --help` (exit 0) and checks `qtscrob` is executable
+5. Uploads two artifacts:
+   - **`build-report`** — markdown table of every stage result (kept 30 days)
+   - **`binaries-linux-x86_64`** — `qtscrob` and `scrobbler` (kept 7 days)
+
+Download artifacts from the **Actions** tab → select the workflow run → **Artifacts** section at the bottom of the run summary page.
+
+---
+
+## Release (`release.yml`)
+
+**Trigger:** pushing a tag that matches `v[0-9]*` (e.g. `v0.13.5`).
+
+### How to cut a release
+
+```sh
+# 1. Make sure the working tree is clean and on master
+git checkout master
+git pull
+
+# 2. Create an annotated tag (use the version from src/lib/common.h)
+git tag -a v0.13.5 -m "Release 0.13.5"
+
+# 3. Push the tag — this triggers the release workflow
+git push origin v0.13.5
+```
+
+The workflow then:
+1. Installs Qt 6 and dependencies
+2. Builds with CMake in Release mode
+3. Smoke-tests the CLI binary
+4. Strips debug symbols from both binaries (`strip --strip-unneeded`)
+5. Packages them as `qtscrobbler-VERSION-linux-x86_64.tar.gz` together with `README.md`
+6. Generates a build report with sizes and SHA-256 of the archive
+7. Creates a GitHub Release with:
+   - The tarball as a downloadable asset
+   - The build report as the release body
+8. Uploads the build report as an Actions artifact (kept 90 days)
+
+The release appears at **Releases** on the repository's main page.
+
+---
+
+## Downloading and running a release
+
+1. Go to the **Releases** page and pick the version you want.
+2. Download `qtscrobbler-VERSION-linux-x86_64.tar.gz`.
+3. Verify the SHA-256 listed in the release notes:
+
+   ```sh
+   sha256sum qtscrobbler-VERSION-linux-x86_64.tar.gz
+   ```
+
+4. Extract and run:
+
+   ```sh
+   tar -xzf qtscrobbler-VERSION-linux-x86_64.tar.gz
+   cd qtscrobbler-VERSION-linux-x86_64
+
+   ./qtscrob          # GUI
+   ./scrobbler --help # CLI
+   ```
+
+### Runtime requirements
+
+The binaries are dynamically linked against Qt 6 and libmtp. Install those on the target machine before running:
+
+```sh
+# Arch / Manjaro
+sudo pacman -S qt6-base libmtp
+
+# Debian / Ubuntu 24.04
+sudo apt-get install qt6-base-dev libmtp9
+```
+
+---
+
+## Notes
+
+- The `GITHUB_TOKEN` is used automatically by the release workflow — no personal access token needed.
+- CI and release both run on **Linux (Ubuntu 24.04) only**. macOS and Windows are not actively maintained.
+- MTP device support (`libmtp`) is included in the release binaries when `libmtp-dev` is found at build time (it is on the GitHub-hosted runner).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Qt Scrobbler
 
-Initially a clone/fork from the SourceForge project by Tomasz Mon, Robert Keevil and others.
-The code has since been adapted for Qt5 and is now being ported to **Qt6**.
-QTScrobbler ships both a multiplatform GUI and a CLI version.
+Initially a clone/fork from the SourceForge project by Tomasz Mon, Robert Keevil and others. Now maintained by Marcel Petrick.  
+The code has since been adapted for Qt5 and is now being ported to **Qt6**.  
+QTScrobbler ships both a multiplatform GUI and a CLI version.  
 
-Primary supported platform: **Linux**.
+Primary supported platform: **Linux**.  
 macOS and Windows support is not actively maintained.
 
 Optional MTP support requires `libmtp-dev` and `pkg-config`:
@@ -18,62 +18,46 @@ sudo pacman -S libmtp pkgconf                # Arch/Manjaro
 
 ## Requirements
 
-- Qt >= 6.x (tested with Qt 6.11.1)
-- A C++17 capable compiler (GCC 10+ or Clang 12+)
-- `qmake` pointing to Qt6 (verify with `qmake --version`)
+- Qt >= 6.8 (tested with Qt 6.11.1)
+- CMake >= 3.28
+- A C++20 capable compiler (GCC 12+ or Clang 14+)
+- `cmake` and `pkg-config`
 
-On Arch/Manjaro `qmake` already resolves to Qt6.
-On Debian/Ubuntu install `qt6-base-dev` and use `qmake6`.
+On Arch/Manjaro all of the above are available via `pacman`.  
+On Debian/Ubuntu 22.04+ install `qt6-base-dev qt6-tools-dev qt6-tools-dev-tools cmake`.
 
 ---
 
 ## How to build
 
-### most simple: run localPipeline.sh ..
+### most simple: run localPipeline.sh
 
 ```sh
-..
+./localPipeline.sh --noRun
 ============ Local Pipeline Summary ============
- QtScrobbler v0.13.2
+ QtScrobbler v0.13.12
 Qt6 Check              : PASS Qt 6.11.1 at /usr/bin/qmake6
-Build Tools            : PASS make, g++, pkg-config present; 20 compile jobs
-Build: library         : PASS libscrobble.a (672K)
-Translations (.qm)     : PASS .qm files generated
-Build: GUI             : PASS qtscrob (576K)
+Build Tools            : PASS cmake, g++, pkg-config present; 20 compile jobs
+CMake configure        : PASS configured in /path/to/QtScrobbler/build
+CMake build            : PASS libscrobble.a (556K); qtscrob; scrobbler
+Build: GUI             : PASS qtscrob (584K)
 Build: CLI             : PASS scrobbler (340K)
 Smoke: CLI             : PASS --help exited 0 — usage text printed
-Smoke: GUI binary      : PASS /home/mpetrick/repos/QtScrobbler/src/qt/qtscrob — 576K
+Smoke: GUI binary      : PASS /path/to/QtScrobbler/build/qtscrob — 584K
 Translations           : PASS de: 79/0 untranslated;  pl: 79/0 untranslated — total: 158 strings, 0 untranslated
 Unit Tests             : SKIP No QTest suite — add src/tests/ to enable
-Launch App             : PASS qtscrob started (detached)
+Launch App             : SKIP Suppressed by --noRun
 ================================================
 ```
 
-### Full build (library + GUI + CLI)
+### Full build (out-of-tree, all targets)
 
 ```sh
-cd src
-qmake
-make -j$(nproc)
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel $(nproc)
 ```
 
-Binaries are written to `src/qt/` (GUI: `qtscrob`) and `src/cli/` (CLI: `scrobbler`).
-
-### GUI only
-
-```sh
-cd src/qt
-qmake
-make -j$(nproc)
-```
-
-### CLI only
-
-```sh
-cd src/cli
-qmake
-make -j$(nproc)
-```
+Binaries are written to `build/` (GUI: `build/qtscrob`, CLI: `build/scrobbler`).
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+0. bring it down to zero build warnings. check this via the localPipeline as well. a single warning shall make the build fail. add this as flag.
+1. handle the remaining steps from the qt6 porting. like signal and slot connections.
+2. add clang tidy?
+3. add clazy?
+4. add doxygen - as check for undocumented public API. also make it generate the docs.
+5. cppcheck?
+6. automatic testing (right now zeri unit testing, therefore coverage is zero) - is there even a reason to make it work?
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,10 @@
-0. bring it down to zero build warnings. check this via the localPipeline as well. a single warning shall make the build fail. add this as flag.
-1. handle the remaining steps from the qt6 porting. like signal and slot connections.
+fixed: 0. bring it down to zero build warnings. check this via the localPipeline as well. a single warning shall make the build fail. add this as flag.
+fixed: 1. handle the remaining steps from the qt6 porting. like signal and slot connections.
+fixed: 7. bump to cpp20; check for outdated constructs, which can be improved too. whole source code base.
 2. add clang tidy?
 3. add clazy?
 4. add doxygen - as check for undocumented public API. also make it generate the docs.
 5. cppcheck?
 6. automatic testing (right now zeri unit testing, therefore coverage is zero) - is there even a reason to make it work?
-
+8. check all dependencies:; cmake 3.16 - a bit outdated, or? check what is the most recent stable version for all dependencies. then raise them. we want to use modern stuff. does not have o be bbleeding edge, but should be viable and modern. no old crap.
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,6 @@ fixed: 7. bump to cpp20; check for outdated constructs, which can be improved to
 5. cppcheck?
 6. automatic testing (right now zeri unit testing, therefore coverage is zero) - is there even a reason to make it work?
 fixed: 8. check all dependencies:; cmake 3.16 - a bit outdated, or? check what is the most recent stable version for all dependencies. then raise them. we want to use modern stuff. does not have o be bbleeding edge, but should be viable and modern. no old crap.
+9. language support for German, Croatian, Mandarin and Ukrainian - switchable by UI menu; on the fly
+10. translations for all of the language with CuteLingoExpress
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,5 @@ fixed: 7. bump to cpp20; check for outdated constructs, which can be improved to
 4. add doxygen - as check for undocumented public API. also make it generate the docs.
 5. cppcheck?
 6. automatic testing (right now zeri unit testing, therefore coverage is zero) - is there even a reason to make it work?
-8. check all dependencies:; cmake 3.16 - a bit outdated, or? check what is the most recent stable version for all dependencies. then raise them. we want to use modern stuff. does not have o be bbleeding edge, but should be viable and modern. no old crap.
+fixed: 8. check all dependencies:; cmake 3.16 - a bit outdated, or? check what is the most recent stable version for all dependencies. then raise them. we want to use modern stuff. does not have o be bbleeding edge, but should be viable and modern. no old crap.
 

--- a/localPipeline.sh
+++ b/localPipeline.sh
@@ -200,7 +200,7 @@ cmake_configure() {
 # ---------------------------------------------------------------------------
 
 cmake_build() {
-    log "Stage 4 — CMake build (--parallel ${JOBS})..."
+    log "Stage 4 — CMake build (--parallel ${JOBS}, -Wall -Werror enforced)..."
     local log_path="${PIPELINE_LOG_DIR}/cmake_build.log"
 
     if run_with_log "${log_path}" cmake --build "${BUILD_DIR}" --parallel "${JOBS}"; then
@@ -245,10 +245,15 @@ cmake_build() {
         return $?
     fi
 
-    local errors
-    errors="$(grep -cE 'error:' "${log_path}" 2>/dev/null || true)"
-    CMAKE_BUILD_DETAILS="build failed (${errors} error line(s)) — see ${log_path}"
+    local errors warnings
+    errors="$(grep -cE ' error:' "${log_path}" 2>/dev/null || true)"
+    warnings="$(grep -cE ' warning:' "${log_path}" 2>/dev/null || true)"
+    CMAKE_BUILD_DETAILS="build failed (${errors} error(s), ${warnings} warning(s)) — see ${log_path}"
     error "  ${CMAKE_BUILD_DETAILS}"
+    if [[ "${warnings}" -gt 0 ]]; then
+        error "  Warnings treated as errors (-Werror). Fix all warnings before committing."
+        grep -E ' warning:' "${log_path}" | head -10 >&2 || true
+    fi
     return 1
 }
 

--- a/src/cli/app.cpp
+++ b/src/cli/app.cpp
@@ -29,8 +29,8 @@ app::app(int& argc, char** argv) : QCoreApplication(argc, argv)
     scrob = new Scrobble();
     method = SCROBBLE_NONE;
 
-    connect(scrob, SIGNAL(parsing_opened(bool)), this, SLOT(parsed(bool)));
-    connect(scrob, SIGNAL(submission_finished(bool)), this, SLOT(scrobbled(bool)));
+    connect(scrob, &Scrobble::parsing_opened,    this, &app::parsed);
+    connect(scrob, &Scrobble::submission_finished, this, &app::scrobbled);
 }
 
 bool app::parse_cmd(int argc, char** argv)

--- a/src/cli/scrobbler.cpp
+++ b/src/cli/scrobbler.cpp
@@ -25,10 +25,8 @@ int main(int argc, char **argv)
         exit(1);
     
     QTranslator translator;
-    if (QFile::exists(":/language.qm")) {
-        translator.load(":/language");
+    if (translator.load(":/language"))
         cli->installTranslator(&translator);
-    }
 
     // HACK - allows exec() to kick in before run() is called
     // how else are you supposed to get a class setup as a console app in Qt?

--- a/src/cli/scrobbler.cpp
+++ b/src/cli/scrobbler.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 
     // HACK - allows exec() to kick in before run() is called
     // how else are you supposed to get a class setup as a console app in Qt?
-    QTimer::singleShot(100, cli, SLOT(run()));
+    QTimer::singleShot(100, cli, &app::run);
 
     return cli->exec();
 }

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.5"
+#define CLIENT_VERSION "0.13.7"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.7"
+#define CLIENT_VERSION "0.13.8"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.15"
+#define CLIENT_VERSION "0.13.16"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.11"
+#define CLIENT_VERSION "0.13.12"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.4"
+#define CLIENT_VERSION "0.13.5"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.8"
+#define CLIENT_VERSION "0.13.11"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.12"
+#define CLIENT_VERSION "0.13.15"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/common.h
+++ b/src/lib/common.h
@@ -22,7 +22,7 @@
 #include <QtCore>
 
 #define CLIENT_ID "qts"
-#define CLIENT_VERSION "0.13.16"
+#define CLIENT_VERSION "0.13.18"
 #define CLIENT_USERAGENT "QTScrobbler v" CLIENT_VERSION
 #define PROTOCOL_VERSION "1.2"
 #define API_KEY "992b6748eea766062671eccb419aecd0"

--- a/src/lib/conf.cpp
+++ b/src/lib/conf.cpp
@@ -24,7 +24,7 @@ Conf::Conf() :
     del_apple_playlist(false),
     tz_override(false),
     display_utc(false),
-    mru(NULL),
+    mru(),
     proxy_host(QString()),
     proxy_port(0),
     proxy_user(QString()),

--- a/src/lib/gettrackinfo.cpp
+++ b/src/lib/gettrackinfo.cpp
@@ -27,8 +27,7 @@ GetTrackInfo::GetTrackInfo(QObject *parent) :
     request.setUrl(QUrl(API_URL));
     request.setRawHeader("User-Agent", CLIENT_USERAGENT);
 
-    connect(manager, SIGNAL(finished(QNetworkReply*)),
-            this, SLOT(get_finished(QNetworkReply*)));
+    connect(manager, &QNetworkAccessManager::finished, this, &GetTrackInfo::get_finished);
     time.start();
 }
 
@@ -91,12 +90,12 @@ void GetTrackInfo::get_finished(QNetworkReply *reply)
     {
         if (reader->isStartElement())
         {
-            if (reader->name() == "lfm")
+            if (reader->name() == QLatin1String("lfm"))
             {
                 QXmlStreamAttributes attributes = reader->attributes();
                 status = attributes.value("status").toString();
             }
-            if (reader->name() == "duration")
+            if (reader->name() == QLatin1String("duration"))
             {
                 length = reader->readElementText().toInt()/1000;
             }

--- a/src/lib/libscrobble.cpp
+++ b/src/lib/libscrobble.cpp
@@ -49,16 +49,11 @@ Scrobble::Scrobble()
     conf = new Conf();
     api_info = new GetTrackInfo();
     cache = new DBCache();
-    connect(conf, SIGNAL(add_log(LOG_LEVEL,QString)),
-            this, SLOT(add_log(LOG_LEVEL,QString)));
-    connect(api_info, SIGNAL(finished(int,bool,int,int)),
-            this, SLOT(updated_track_length(int,bool,int,int)));
-    connect(api_info, SIGNAL(add_log(LOG_LEVEL,QString)),
-            this, SLOT(add_log(LOG_LEVEL,QString)));
-    connect(this, SIGNAL(missing_times_get(int,scrob_entry,int)),
-            api_info, SLOT(get(int,scrob_entry,int)));
-    connect(cache, SIGNAL(add_log(LOG_LEVEL,QString)),
-            this, SLOT(add_log(LOG_LEVEL,QString)));
+    connect(conf,     &Conf::add_log,         this,     &Scrobble::add_log);
+    connect(api_info, &GetTrackInfo::finished, this,     &Scrobble::updated_track_length);
+    connect(api_info, &GetTrackInfo::add_log,  this,     &Scrobble::add_log);
+    connect(this,     &Scrobble::missing_times_get, api_info, &GetTrackInfo::get);
+    connect(cache,    &DBCache::add_log,       this,     &Scrobble::add_log);
     api_info->start();
     conf->load_config();
     error_str = "";
@@ -398,18 +393,11 @@ bool Scrobble::submit()
 
             submissions[i]->init(conn);
 
-            connect(submissions[i],
-                    SIGNAL(finished(bool, QString)),
-                    this, SLOT(submit_finished(bool, QString)));
-            connect(submissions[i],
-                    SIGNAL(add_log(LOG_LEVEL,QString)),
-                    this, SLOT(add_log(LOG_LEVEL, QString)));
-
-            //if something while submitting fails, then notify the scrobbler which will also break the progress(-dialog) if necessary
-            connect(submissions[i],
-                    SIGNAL(signalHandshakeFailure(QString)),
-                    this,
-                    SLOT(slotCancelProgress())/*, Qt::DirectConnection*/); //the real stuff: submission -> scrobbler -> progress
+            connect(submissions[i], &Submit::finished,  this, &Scrobble::submit_finished);
+            connect(submissions[i], &Submit::add_log,   this, &Scrobble::add_log);
+            // signalHandshakeFailure carries a QString the slot does not consume — use lambda
+            connect(submissions[i], &Submit::signalHandshakeFailure,
+                    this, [this](const QString &) { slotCancelProgress(); });
 
             submissions[i]->do_submit();
         }
@@ -503,14 +491,10 @@ bool Scrobble::parse(SCROBBLE_METHOD method, QString path)
     }
     scrobble_method = method;
 
-    connect(parser, SIGNAL(add_log(LOG_LEVEL, QString)),
-            this, SLOT(add_log(LOG_LEVEL, QString)));
-    connect(parser, SIGNAL(entry(scrob_entry)),
-            this, SLOT(add_entry(scrob_entry)));
-    connect(parser, SIGNAL(open_finished(bool, QString)),
-            this, SLOT(parser_open_finished(bool, QString)));
-    connect(parser, SIGNAL(clear_finished(bool, QString)),
-            this, SLOT(parser_clear_finished(bool, QString)));
+    connect(parser, &Parse::add_log,        this, &Scrobble::add_log);
+    connect(parser, &Parse::entry,          this, &Scrobble::add_entry);
+    connect(parser, &Parse::open_finished,  this, &Scrobble::parser_open_finished);
+    connect(parser, &Parse::clear_finished, this, &Scrobble::parser_clear_finished);
 
     parser->open(path, offset);
 

--- a/src/lib/parse-ipod.cpp
+++ b/src/lib/parse-ipod.cpp
@@ -236,7 +236,7 @@ void Parse_Ipod::parse_db(QString folder_path, int tz, QByteArray &data)
                 }
 
                 buffer[ ucs2len ] = 0;
-                QString temp = QString::fromUtf16(buffer);
+                QString temp = QString::fromUtf16(reinterpret_cast<const char16_t *>(buffer));
                 delete [] buffer;
 
 

--- a/src/lib/submit.cpp
+++ b/src/lib/submit.cpp
@@ -26,10 +26,8 @@ Submit::Submit(int submit_index)
     nam_submit = new QNetworkAccessManager();
     nr_handshake = nr_submit = NULL;
 
-    connect(nam_handshake, SIGNAL(finished(QNetworkReply*)),
-         this, SLOT(handshake_finished(QNetworkReply*)));
-    connect(nam_submit, SIGNAL(finished(QNetworkReply*)),
-         this, SLOT(senddata_finished(QNetworkReply*)));
+    connect(nam_handshake, &QNetworkAccessManager::finished, this, &Submit::handshake_finished);
+    connect(nam_submit,    &QNetworkAccessManager::finished, this, &Submit::senddata_finished);
 
     scrob_init = false;
     submission_ok = false;
@@ -123,7 +121,7 @@ void Submit::senddata()
     if (0 == entry_index.size())
     {
         // should never be true...
-        nr_submit->disconnect(SIGNAL(uploadProgress(qint64, qint64)));
+        QObject::disconnect(nr_submit, &QNetworkReply::uploadProgress, nullptr, nullptr);
         nr_submit->deleteLater();
         emit finished(false, tr("%1: Error, attempted to send an empty submission!")
                       .arg(SITE_NAME[index]));
@@ -156,7 +154,7 @@ void Submit::senddata_finished(QNetworkReply *reply)
 {
     //emit add_log(LOG_INFO, "Submit::senddata_finished");
     if ( reply->error() != QNetworkReply::NoError ) {
-        nr_submit->disconnect(SIGNAL(uploadProgress(qint64, qint64)));
+        QObject::disconnect(nr_submit, &QNetworkReply::uploadProgress, nullptr, nullptr);
         nr_submit->deleteLater();
         emit finished(false, tr("SUBMIT %1: Request failed, %2")
                       .arg(SITE_NAME[index], reply->errorString()));
@@ -192,7 +190,7 @@ void Submit::senddata_finished(QNetworkReply *reply)
         else if (result.contains("FAILED"))
         {
             emit add_log(LOG_INFO, QString("%1: Submission FAILED").arg(SITE_NAME[index]));
-            nr_submit->disconnect(SIGNAL(uploadProgress(qint64, qint64)));
+            QObject::disconnect(nr_submit, &QNetworkReply::uploadProgress, nullptr, nullptr);
             nr_submit->deleteLater();
             emit finished(false,
                           tr("%1: Server returned an error after sending data")
@@ -224,7 +222,7 @@ void Submit::senddata_finished(QNetworkReply *reply)
             {
                 emit add_log(LOG_DEBUG, QString("%1: Submission complete")
                              .arg(SITE_NAME[index]));
-                nr_submit->disconnect(SIGNAL(uploadProgress(qint64, qint64)));
+                QObject::disconnect(nr_submit, &QNetworkReply::uploadProgress, nullptr, nullptr);
                 nr_submit->deleteLater();
                 nr_handshake->deleteLater();
                 submission_ok = true;
@@ -234,7 +232,7 @@ void Submit::senddata_finished(QNetworkReply *reply)
     }
     else
     {
-        nr_submit->disconnect(SIGNAL(uploadProgress(qint64, qint64)));
+        QObject::disconnect(nr_submit, &QNetworkReply::uploadProgress, nullptr, nullptr);
         nr_submit->deleteLater();
         emit finished(false, tr("%1: Empty result from server")
                       .arg(SITE_NAME[index]));

--- a/src/qt/src/console.cpp
+++ b/src/qt/src/console.cpp
@@ -42,18 +42,17 @@ Console::Console(QTScrob *parent) : QDialog(parent) {
 
 	comboLevel->setEditable(false);
 
-	connect(comboLevel, SIGNAL(currentIndexChanged(int)),
-		this, SLOT(set_spin_level(int)));
+	connect(comboLevel, &QComboBox::currentIndexChanged, this, &Console::set_spin_level);
 
 	current_level = LOG_DEFAULT;
 	comboLevel->setCurrentIndex(current_level);
 
 	timerConsole = new QTimer();
-	connect(timerConsole, SIGNAL(timeout()), this, SLOT(update()));
+	connect(timerConsole, &QTimer::timeout, this, &Console::update);
 	timerConsole->start(250);
 
 	btncopy = new QPushButton(tr("Copy to clipboard"));
-	connect(btncopy, SIGNAL(released()), this, SLOT(copy()));
+	connect(btncopy, &QPushButton::released, this, &Console::copy);
 
 	QHBoxLayout *btmlayout = new QHBoxLayout;
 	btmlayout->addWidget(lblCombo);

--- a/src/qt/src/main.cpp
+++ b/src/qt/src/main.cpp
@@ -51,10 +51,8 @@ int main(int argc, char **argv)
     app.setApplicationName("QTScrobbler");
 
     QTranslator translator;
-    if (QFile::exists(":/language.qm")) {
-        translator.load(":/language");
+    if (translator.load(":/language"))
         app.installTranslator(&translator);
-    }
 
     QTextStream out(stdout);
 

--- a/src/qt/src/progress.cpp
+++ b/src/qt/src/progress.cpp
@@ -36,7 +36,7 @@ Progress::Progress(QTScrob *parent) : QDialog( parent ) {
     layout = new QVBoxLayout(this);
     btn_cancel = new QPushButton(tr("Cancel"), this);
 
-    connect(btn_cancel, SIGNAL(clicked()), this, SLOT(cancel()));
+    connect(btn_cancel, &QPushButton::clicked, this, &Progress::cancel);
 
     QHashIterator<int, Submit *> i(qtscrob->scrob->submissions);
     while (i.hasNext())
@@ -50,10 +50,7 @@ Progress::Progress(QTScrob *parent) : QDialog( parent ) {
         layout->addSpacing(10);
         sites.insert(index, prog);
 
-        connect(i.value(),
-                SIGNAL(progress(int, int, int)),
-                this,
-                SLOT(update_progress(int, int, int)));
+        connect(i.value(), &Submit::progress, this, &Progress::update_progress);
     }
 
     layout->addWidget(btn_cancel);
@@ -62,7 +59,7 @@ Progress::Progress(QTScrob *parent) : QDialog( parent ) {
 
 Progress::~Progress()
 {
-    disconnect(btn_cancel, SIGNAL(clicked()), this, SLOT(cancel()));
+    disconnect(btn_cancel, &QPushButton::clicked, this, &Progress::cancel);
 }
 
 void Progress::cancel(void)

--- a/src/qt/src/qtscrob.cpp
+++ b/src/qt/src/qtscrob.cpp
@@ -511,44 +511,29 @@ void QTScrob::recalcDT(void) {
 
 void QTScrob::deleteRow() {
 	if (logTable->rowCount()) { // Items are displayed. 
-	if (logTable->rowCount() == 1) { // Handle it as one item. 
+	if (logTable->rowCount() == 1) { // Handle it as one item.
         QTableWidgetItem * artist = logTable->item(logTable->currentRow(),0);
         QTableWidgetItem * title = logTable->item(logTable->currentRow(),2);
-		QMessageBox mb(QCoreApplication::applicationName(),
-			tr("Are you sure you want to delete: %1 - %2?")
-			.arg(artist->text(), title->text()),
-				QMessageBox::Information,
-				QMessageBox::Yes | QMessageBox::Default,
-				QMessageBox::No, 0);
-			mb.setButtonText(QMessageBox::Yes, "Yes");
-			mb.setButtonText(QMessageBox::No, "No");
-			switch(mb.exec()) {
-				case QMessageBox::Yes:
-					scrob->remove_track(logTable->currentRow());
-					break;
-				case QMessageBox::No:
-					break;
-			}
-	} else { // More than one item. 
-		QMessageBox mb(QCoreApplication::applicationName(), \
-			tr("Are you sure you want to delete the selected items") + "?", \
-			QMessageBox::Information, \
-			QMessageBox::Yes | QMessageBox::Default, \
-			QMessageBox::No, 0);
-		mb.setButtonText(QMessageBox::Yes, "Yes");
-		mb.setButtonText(QMessageBox::No, "No");
-		switch(mb.exec()) {
-			case QMessageBox::Yes:
-				for (int i = logTable->rowCount() - 1; i >= 0; i--) { 
-					if (logTable->item(i, 0)->isSelected())
-						scrob->remove_track(i); 
-				}
-
-				break;
-			case QMessageBox::No:
-				break;
-			}
-		}
+        if (QMessageBox::question(this,
+                QCoreApplication::applicationName(),
+                tr("Are you sure you want to delete: %1 - %2?")
+                    .arg(artist->text(), title->text()),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No) == QMessageBox::Yes) {
+            scrob->remove_track(logTable->currentRow());
+        }
+    } else { // More than one item.
+        if (QMessageBox::question(this,
+                QCoreApplication::applicationName(),
+                tr("Are you sure you want to delete the selected items?"),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No) == QMessageBox::Yes) {
+            for (int i = logTable->rowCount() - 1; i >= 0; i--) {
+                if (logTable->item(i, 0)->isSelected())
+                    scrob->remove_track(i);
+            }
+        }
+    }
 	}
 
 	loadtable();
@@ -613,7 +598,7 @@ void QTScrob::changeRow(int r, int c) {
 			if (!logTable->item(r, c)->text().isEmpty())
 			{
 				QDateTime dt = QDateTime::fromString(logTable->item(r, c)->text(), "yyyy-MM-dd hh:mm:ss");
-				dt.setTimeSpec(Qt::UTC);
+				dt.setTimeZone(QTimeZone::utc());
 				tmp.when = dt.toSecsSinceEpoch();
 			}
 			break;

--- a/src/qt/src/qtscrob.cpp
+++ b/src/qt/src/qtscrob.cpp
@@ -22,6 +22,7 @@
 #include "about.h"
 #include "help.h"
 #include "progress.h"
+#include "missingtimeprogress.h"
 #include "console.h"
 
 #include <QTime>
@@ -238,37 +239,30 @@ void QTScrob::DT_labels()
 }
 
 void QTScrob::connectSlots() {
-	connect(actOpen, SIGNAL(triggered()), this, SLOT(open_log()));
-	connect(actExit, SIGNAL(triggered()), this, SLOT(close()));
-	connect(actHelp, SIGNAL(triggered()), this, SLOT(help()));
-	connect(actAbout, SIGNAL(triggered()), this, SLOT(about()));
-	connect(actAboutQt, SIGNAL(triggered()), this, SLOT(aboutQt()));
-	connect(actOpeniTunes, SIGNAL(triggered()), this, SLOT(open_ipod()));
-	connect(actConsole, SIGNAL(triggered()), this, SLOT(console()));
+    connect(actOpen,      &QAction::triggered, this, &QTScrob::open_log);
+    connect(actExit,      &QAction::triggered, this, &QWidget::close);
+    connect(actHelp,      &QAction::triggered, this, &QTScrob::help);
+    connect(actAbout,     &QAction::triggered, this, &QTScrob::about);
+    connect(actAboutQt,   &QAction::triggered, this, &QTScrob::aboutQt);
+    connect(actOpeniTunes,&QAction::triggered, this, &QTScrob::open_ipod);
+    connect(actConsole,   &QAction::triggered, this, &QTScrob::console);
 #ifdef HAVE_MTP
-	connect(actOpenMTP, SIGNAL(triggered()), this, SLOT(open_mtp()));
-	connect(btnOpenMTP, SIGNAL(clicked()), this, SLOT(open_mtp()));
+    connect(actOpenMTP,  &QAction::triggered,     this, &QTScrob::open_mtp);
+    connect(btnOpenMTP,  &QPushButton::clicked,   this, &QTScrob::open_mtp);
 #endif
-	connect(btnOpeniTunes, SIGNAL(clicked()), this, SLOT(open_ipod()));
-	connect(btnOpen, SIGNAL(clicked()), this, SLOT(open_log()));
-	connect(btnDelete, SIGNAL(clicked()), this, SLOT(deleteRow()));
-	connect(btnSubmit, SIGNAL(clicked()), this, SLOT(scrobble()));
-	connect(actSettings, SIGNAL(triggered()), this, SLOT(settings()));
-	connect(btnRecalcDT, SIGNAL(clicked()), this, SLOT(recalcDT()));
-    connect(DTedit, SIGNAL(dateTimeChanged(QDateTime)),
-            this, SLOT(updaterecalcDT(QDateTime)));
-    connect(logTable, SIGNAL(cellChanged(int, int)),
-            this, SLOT(changeRow(int, int)));
-    connect(scrob, SIGNAL(submission_finished(bool)),
-            this, SLOT(scrobbled(bool)));
-	connect(scrob, SIGNAL(parsing_opened(bool)), this, SLOT(parsed(bool)));
-
-    connect(scrob, SIGNAL(missing_times_start(int)),
-            this, SLOT(missing_times_start(int)));
-    connect(scrob, SIGNAL(missing_times_progress(int)),
-            this, SLOT(missing_times_progress(int)));
-    connect(scrob, SIGNAL(missing_times_finished()),
-            this, SLOT(missing_times_finished()));
+    connect(btnOpeniTunes, &QPushButton::clicked, this, &QTScrob::open_ipod);
+    connect(btnOpen,       &QPushButton::clicked, this, &QTScrob::open_log);
+    connect(btnDelete,     &QPushButton::clicked, this, &QTScrob::deleteRow);
+    connect(btnSubmit,     &QPushButton::clicked, this, &QTScrob::scrobble);
+    connect(actSettings,   &QAction::triggered,   this, &QTScrob::settings);
+    connect(btnRecalcDT,   &QPushButton::clicked, this, &QTScrob::recalcDT);
+    connect(DTedit,  &QDateTimeEdit::dateTimeChanged, this, &QTScrob::updaterecalcDT);
+    connect(logTable, &QTableWidget::cellChanged,     this, &QTScrob::changeRow);
+    connect(scrob, &Scrobble::submission_finished,    this, &QTScrob::scrobbled);
+    connect(scrob, &Scrobble::parsing_opened,         this, &QTScrob::parsed);
+    connect(scrob, &Scrobble::missing_times_start,    this, &QTScrob::missing_times_start);
+    connect(scrob, &Scrobble::missing_times_progress, this, &QTScrob::missing_times_progress);
+    connect(scrob, &Scrobble::missing_times_finished, this, &QTScrob::missing_times_finished);
 }
 
 void QTScrob::help() {
@@ -401,7 +395,7 @@ void QTScrob::loadtable(void) {
 	int i;
 	scrob_entry scrob_tmp;
 
-	logTable->disconnect(SIGNAL(cellChanged(int, int)));
+    QObject::disconnect(logTable, &QTableWidget::cellChanged, nullptr, nullptr);
 
 	logTable->clearContents();
 
@@ -454,7 +448,7 @@ void QTScrob::loadtable(void) {
 	}
 	QApplication::restoreOverrideCursor();
 
-	connect(logTable, SIGNAL(cellChanged(int, int)), this, SLOT(changeRow(int, int)));
+    connect(logTable, &QTableWidget::cellChanged, this, &QTScrob::changeRow);
 }
 
 /*!
@@ -632,7 +626,7 @@ void QTScrob::scrobble() {
         if (winProgress==NULL)
         {
             winProgress = new Progress(this);
-            connect(scrob, SIGNAL(signalCancelProgress()), winProgress, SLOT(cancel())); //new connection, which allows to break&close the progress-dialog
+            connect(scrob, &Scrobble::signalCancelProgress, winProgress, &Progress::cancel);
         }
         winProgress->show();
     }
@@ -697,8 +691,8 @@ void QTScrob::settings_close()
 void QTScrob::missing_times_start(int total)
 {
     progress_missing = new MissingTimeProgress(total, this);
-    connect(this, SIGNAL(update_missing_times_progress(int)),
-            progress_missing, SLOT(update_progress(int)));
+    connect(this, &QTScrob::update_missing_times_progress,
+            progress_missing, &MissingTimeProgress::update_progress);
     progress_missing->show();
 }
 

--- a/src/qt/src/settings.cpp
+++ b/src/qt/src/settings.cpp
@@ -94,8 +94,8 @@ Settings::Settings(QTScrob *parent) : QDialog( parent )
 	cmb_tz_min->setCurrentIndex(abs(qtscrob->scrob->conf->utc_offset % 3600) / 900);
 	grpManual->setChecked(qtscrob->scrob->conf->tz_override);
 
-    connect(btnOK, SIGNAL(clicked()), this, SLOT(save()));
-	connect(btnCancel, SIGNAL(clicked()), qtscrob, SLOT(settings_close()));
+    connect(btnOK,     &QPushButton::clicked, this,    &Settings::save);
+    connect(btnCancel, &QPushButton::clicked, qtscrob, &QTScrob::settings_close);
 
     tabWidget->setCurrentIndex(0);
 }

--- a/src/qt/src/ui/settingsWin.ui
+++ b/src/qt/src/ui/settingsWin.ui
@@ -275,7 +275,7 @@ p, li { white-space: pre-wrap; }
              <number>0</number>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
             </property>
             <property name="frame">
              <bool>true</bool>
@@ -448,7 +448,7 @@ p, li { white-space: pre-wrap; }
              <number>0</number>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
             </property>
             <property name="frame">
              <bool>true</bool>


### PR DESCRIPTION
Closes #6

Two workflows:
- ci.yml: builds and smoke-tests on every push/PR (Ubuntu 24.04 / Qt6)
  uploads build-report artifact (30 d) and binaries artifact (7 d)
- release.yml: triggered by v* tags; strips binaries, packages a
  linux-x86_64 tarball with SHA-256, creates a GitHub Release with
  the archive as a downloadable asset and the build report as the
  release body (artifact kept 90 d)

Add GITHUB_ACTIONS.md documenting how CI works, how to cut a release
via git tag, and the runtime requirements for end users.
